### PR TITLE
update Dockerfile to set a WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN           bash /tmp/run.sh
 # Let's make sure the app built correctly
 RUN           ffmpeg -buildconf 
 
-
+WORKDIR /tmp/workdir
 
 CMD           ["--help"]
 ENTRYPOINT    ["ffmpeg"]


### PR DESCRIPTION
explicity set WORKDIR to /tmp/workdir so that it's possible to map a volume to preserve passlogfile between executions. 
this enable two pass encoding, for example:
 
#vp9 costant quality
MAPDIR = # directory in the host system
INPUT = # file to encode 
docker run -v "${MAPDIR}":/tmp/workdir/ jrottenberg/ffmpeg -y -i /tmp/workdir/"${INPUT}" -c:v libvpx-vp9 -pass 1 -b:v 0 -crf 33 -threads 8 -speed 4 \
    -tile-columns 6 -frame-parallel 1 -auto-alt-ref 1 -lag-in-frames 25 \
    -an -f webm /dev/null
 
docker run -v "${MAPDIR}":/tmp/workdir/ jrottenberg/ffmpeg -i /tmp/workdir/"${INPUT}" -c:v libvpx-vp9 -pass 2 -b:v 0 -crf 33 -threads 8 -speed 2 \
    -tile-columns 6 -frame-parallel 1 -auto-alt-ref 1 -lag-in-frames 25 \
    -c:a libopus -b:a 64k -f webm /tmp/workdir/"${INPUT}".costant.webm