### PR TITLE
Update to x265 multilib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.1.2 \
+ENV         FFMPEG_VERSION=3.1.3 \
             FAAC_VERSION=1.28    \
             FDKAAC_VERSION=0.1.4 \
             LAME_VERSION=3.99.5  \
@@ -25,36 +25,36 @@ ENV         FFMPEG_VERSION=3.1.2 \
             VORBIS_VERSION=1.3.5 \
             VPX_VERSION=1.6.0    \
             XVID_VERSION=1.3.4   \
-            X265_VERSION=1.9     \
+            X265_VERSION=2.0     \
+            X264_VERSION=last_stable \
             SRC=/usr/local
 
-RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
+RUN      buildDeps="autoconf \
+                   automake \
+                   bzip2 \
+                   ca-certificates \
+                   cmake \
+                   curl \
+                   g++ \
+                   gcc \
+                   git \
+                   libssl-dev \
+                   libtool \
+                   make \
+                   nasm \
+                   perl \
+                   pkg-config \
+                   python \
+                   tar \
+                   xmlto \
+                   zlib1g-dev" && \
+        export MAKEFLAGS="-j$(($(nproc) + 1))" && \
         apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends \
-        autoconf \
-        automake \
-        bzip2 \
-        ca-certificates \
-        cmake \
-        curl \
-        g++ \
-        gcc \
-        git \
-        libssl-dev \
-        libtool \
-        make \
-        nasm \
-        perl \
-        pkg-config \
-        python \
-        tar \
-        xmlto \
-        zlib1g-dev && \
+        apt-get install -yq --no-install-recommends $buildDeps && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# yasm
+# yasm http://yasm.tortall.net/
         curl -sL https://github.com/yasm/yasm/archive/v${YASM_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd ${DIR}/yasm-${YASM_VERSION} && \
+        tar -zx --strip-components=1 && \
         ./autogen.sh && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --docdir=${DIR} -mandir=${DIR}&& \
         make && \
@@ -62,39 +62,35 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x264  TODO : pin version, at least we use the stable branch
-        git clone -b stable  --single-branch --depth 1 git://git.videolan.org/x264 && \
-        cd x264 && \
+# x264 http://www.videolan.org/developers/x264.html TODO : pin version, at least we use the stable branch
+        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/${X264_VERSION}_x264.tar.bz2 | \
+        tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --enable-static && \
         make && \
         make install && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x265
+# x265 http://x265.org/
         curl -s https://download.videolan.org/pub/videolan/x265/x265_${X265_VERSION}.tar.gz  | \
-        tar zxf - -C . && \
-        cd x265_${X265_VERSION}/source && \
-        cmake -G "Unix Makefiles" . && \
-        cmake . && \
-        make && \
-        make install && \
+        tar -zx && \
+        cd x265_${X265_VERSION}/build/linux && \
+        sh multilib.sh && \
+        make -C 8bit install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libogg
+#libogg https://www.xiph.org/ogg/ 
         curl -sL http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd libogg-${OGG_VERSION} && \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --datadir=${DIR} && \
         make && \
         make install && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libopus
+#libopus https://www.opus-codec.org/
         curl -sL http://downloads.xiph.org/releases/opus/opus-${OPUS_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd opus-${OPUS_VERSION} && \
+        tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
         make && \
@@ -102,10 +98,9 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libvorbis
+#libvorbis https://xiph.org/vorbis/
         curl -sL http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd libvorbis-${VORBIS_VERSION} && \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
         --disable-shared --datadir="${DIR}" && \
         make && \
@@ -113,10 +108,9 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libtheora
+#libtheora http://www.theora.org/
         curl -sL http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.bz2 | \
-        tar jxvf - -C . && \
-        cd libtheora-${THEORA_VERSION} && \
+        tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
         --disable-shared --datadir="${DIR}" && \
         make && \
@@ -124,30 +118,27 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libvpx
+#libvpx https://www.webmproject.org/code/
         curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | \
-        tar zxf - -C . && \
-        cd libvpx-${VPX_VERSION} && \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --enable-vp8 --enable-vp9 --disable-examples --disable-docs && \
         make && \
         make install && \
         make clean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libmp3lame
-        curl -Ls https://downloads.sf.net/project/lame/lame/${LAME_VERSION%.*}/lame-${LAME_VERSION}.tar.gz \
-        | tar zxf - -C . && \
-        cd lame-${LAME_VERSION} && \
+#libmp3lame http://lame.sourceforge.net/
+        curl -Ls https://downloads.sf.net/project/lame/lame/${LAME_VERSION%.*}/lame-${LAME_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --enable-nasm --datadir="${DIR}" && \
         make && \
         make install && \
         make distclean&& \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#faac + http://stackoverflow.com/a/4320377
+#faac https://sourceforge.net/projects/faac/ +  http://stackoverflow.com/a/4320377
         curl -Lss https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd faac-${FAAC_VERSION} && \
+        tar -zx --strip-components=1 && \
         sed -i '126d' common/mp4v2/mpeg4ip.h && \
         ./bootstrap && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \
@@ -155,19 +146,18 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#xvid
+#xvid https://www.xvid.com/
         curl -L -s  http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
-        tar zxf - -C . && \
+        tar -zx && \
         cd xvidcore/build/generic && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \
         make && \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#fdk-aac
-        curl -sL https://codeload.github.com/mstorsjo/fdk-aac/tar.gz/v${FDKAAC_VERSION} | \
-        tar zxf - -C . && \
-        cd fdk-aac-${FDKAAC_VERSION} && \
+#fdk-aac https://github.com/mstorsjo/fdk-aac
+        curl -sL https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
         make && \
@@ -175,10 +165,9 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-## ffmpeg
+## ffmpeg https://ffmpeg.org/
         curl -sL http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | \
-        tar zxf - -C . && \
-        cd ffmpeg-${FFMPEG_VERSION} && \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" \
         --extra-cflags="-I${SRC}/include" \
         --extra-ldflags="-L${SRC}/lib" \
@@ -213,23 +202,7 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         rm -rf ${DIR} && \
 # cleanup
         cd && \
-        apt-get purge -yqq \
-        autoconf \
-        automake \
-        bzip2 \
-        cmake \
-        g++ \
-        gcc \
-        git \
-        libtool \
-        libssl-dev \
-        make \
-        nasm \
-        perl \
-        pkg-config \
-        python \
-        xmlto \
-        zlib1g-dev && \
+        apt-get purge -yqq $buildDeps\
         apt-get autoremove -y && \
         apt-get clean -y && \
         rm -rf /var/lib/apt/lists && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,33 +26,30 @@ ENV         FFMPEG_VERSION=3.1.3 \
             VPX_VERSION=1.6.0    \
             XVID_VERSION=1.3.4   \
             X265_VERSION=2.0     \
-            X264_VERSION=last_stable \
+            X264_VERSION=20160826-2245-stable \
             SRC=/usr/local
 
 RUN      buildDeps="autoconf \
-                   automake \
-                   bzip2 \
-                   ca-certificates \
-                   cmake \
-                   curl \
-                   g++ \
-                   gcc \
-                   git \
-                   libssl-dev \
-                   libtool \
-                   make \
-                   nasm \
-                   perl \
-                   pkg-config \
-                   python \
-                   tar \
-                   xmlto \
-                   zlib1g-dev" && \
+                    automake \
+                    cmake \
+                    curl \
+                    bzip2 \
+                    g++ \
+                    gcc \
+                    git \
+                    libtool \
+                    make \
+                    nasm \
+                    perl \
+                    pkg-config \
+                    python \
+                    libssl-dev \
+                    zlib1g-dev" && \
         export MAKEFLAGS="-j$(($(nproc) + 1))" && \
         apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends $buildDeps && \
+        apt-get install -yq --no-install-recommends ${buildDeps} ca-certificates && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# yasm http://yasm.tortall.net/
+## yasm http://yasm.tortall.net/
         curl -sL https://github.com/yasm/yasm/archive/v${YASM_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         ./autogen.sh && \
@@ -62,8 +59,8 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x264 http://www.videolan.org/developers/x264.html TODO : pin version, at least we use the stable branch
-        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/${X264_VERSION}_x264.tar.bz2 | \
+## x264 http://www.videolan.org/developers/x264.html TODO : pin version, at least we use the stable branch
+        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
         tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --enable-static && \
         make && \
@@ -71,7 +68,7 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x265 http://x265.org/
+## x265 http://x265.org/
         curl -s https://download.videolan.org/pub/videolan/x265/x265_${X265_VERSION}.tar.gz  | \
         tar -zx && \
         cd x265_${X265_VERSION}/build/linux && \
@@ -79,7 +76,7 @@ RUN      buildDeps="autoconf \
         make -C 8bit install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libogg https://www.xiph.org/ogg/ 
+## libogg https://www.xiph.org/ogg/ 
         curl -sL http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --datadir=${DIR} && \
@@ -88,7 +85,7 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libopus https://www.opus-codec.org/
+## libopus https://www.opus-codec.org/
         curl -sL http://downloads.xiph.org/releases/opus/opus-${OPUS_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
@@ -98,7 +95,7 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libvorbis https://xiph.org/vorbis/
+## libvorbis https://xiph.org/vorbis/
         curl -sL http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
@@ -108,7 +105,7 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libtheora http://www.theora.org/
+#@ libtheora http://www.theora.org/
         curl -sL http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.bz2 | \
         tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
@@ -118,7 +115,7 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libvpx https://www.webmproject.org/code/
+## libvpx https://www.webmproject.org/code/
         curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | \
         tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --enable-vp8 --enable-vp9 --disable-examples --disable-docs && \
@@ -127,7 +124,7 @@ RUN      buildDeps="autoconf \
         make clean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#libmp3lame http://lame.sourceforge.net/
+## libmp3lame http://lame.sourceforge.net/
         curl -Ls https://downloads.sf.net/project/lame/lame/${LAME_VERSION%.*}/lame-${LAME_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --enable-nasm --datadir="${DIR}" && \
@@ -136,8 +133,8 @@ RUN      buildDeps="autoconf \
         make distclean&& \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#faac https://sourceforge.net/projects/faac/ +  http://stackoverflow.com/a/4320377
-        curl -Lss https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
+## faac https://sourceforge.net/projects/faac/ +  http://stackoverflow.com/a/4320377
+        curl -L https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         sed -i '126d' common/mp4v2/mpeg4ip.h && \
         ./bootstrap && \
@@ -146,8 +143,8 @@ RUN      buildDeps="autoconf \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#xvid https://www.xvid.com/
-        curl -L -s  http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
+## xvid https://www.xvid.com/
+        curl -sL http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
         tar -zx && \
         cd xvidcore/build/generic && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \
@@ -155,7 +152,7 @@ RUN      buildDeps="autoconf \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-#fdk-aac https://github.com/mstorsjo/fdk-aac
+## fdk-aac https://github.com/mstorsjo/fdk-aac
         curl -sL https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
@@ -200,9 +197,10 @@ RUN      buildDeps="autoconf \
         make qt-faststart && \
         cp qt-faststart ${SRC}/bin && \
         rm -rf ${DIR} && \
-# cleanup
+ ## cleanup
         cd && \
-        apt-get purge -yqq $buildDeps\
+        echo "purge" && \
+        apt-get purge -y ${buildDeps} && \
         apt-get autoremove -y && \
         apt-get clean -y && \
         rm -rf /var/lib/apt/lists && \

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.1.2 \
+ENV         FFMPEG_VERSION=3.1.3 \
             FAAC_VERSION=1.28    \
             FDKAAC_VERSION=0.1.4 \
             LAME_VERSION=3.99.5  \
@@ -24,32 +24,33 @@ ENV         FFMPEG_VERSION=3.1.2 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
             VPX_VERSION=1.6.0    \
-            XVID_VERSION=1.3.4   \
-            X265_VERSION=1.9     \
+            XVID_VERSION=1.3.5   \
+            X265_VERSION=2.0     \
             SRC=/usr/local       \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
+RUN     buildDeps="autoconf \
+                   automake \
+                   bzip2 \
+                   cmake \
+                   gcc \
+                   gcc-c++ \
+                   git \
+                   libtool \
+                   make \
+                   nasm \
+                   perl \
+                   openssl-devel \
+                   tar \
+                   which \
+                   zlib-devel" && \
+        export MAKEFLAGS="-j$(($(nproc) + 1))" && \
         echo "${SRC}/lib" > /etc/ld.so.conf.d/libc.conf && \
-        yum install -y autoconf \
-        automake \
-        bzip2 \
-        cmake \
-        gcc \
-        gcc-c++ \
-        git \
-        libtool \
-        make \
-        nasm \
-        perl \
-        openssl-devel \
-        tar \
-        which \
-        zlib-devel && \
+        yum install -y  && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# yasm
-        curl -sLL https://github.com/yasm/yasm/archive/v${YASM_VERSION}.tar.gz | tar zxf - -C . && \
-        cd ${DIR}/yasm-${YASM_VERSION} && \
+# yasm http://yasm.tortall.net/
+        curl -sL https://github.com/yasm/yasm/archive/v${YASM_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./autogen.sh && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --docdir=${DIR} -mandir=${DIR}&& \
         make && \
@@ -57,37 +58,35 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x264  TODO : pin version, at least we use the stable branch
-        git clone -b stable  --single-branch --depth 1 git://git.videolan.org/x264 && \
-        cd x264 && \
+# x264 http://www.videolan.org/developers/x264.html TODO : pin version, at least we use the stable branch
+        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/${X264_VERSION}_x264.tar.bz2 | \
+        tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --enable-static && \
         make && \
         make install && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# x265
+# x265 http://x265.org/
         curl -s https://download.videolan.org/pub/videolan/x265/x265_${X265_VERSION}.tar.gz  | \
-        tar zxf - -C . && \
-        cd x265_${X265_VERSION}/source && \
-        cmake -G "Unix Makefiles" . && \
-        cmake . && \
-        make && \
-        make install && \
+        tar -zx && \
+        cd x265_${X265_VERSION}/build/linux && \
+        sh multilib.sh && \
+        make -C 8bit install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libogg
-        curl -sL http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz | tar zxf - -C . && \
-        cd libogg-${OGG_VERSION} && \
+#libogg https://www.xiph.org/ogg/ 
+        curl -sL http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --datadir=${DIR} && \
         make && \
         make install && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libopus
-        curl -sL http://downloads.xiph.org/releases/opus/opus-${OPUS_VERSION}.tar.gz | tar zxf - -C . && \
-        cd opus-${OPUS_VERSION} && \
+#libopus https://www.opus-codec.org/
+        curl -sL http://downloads.xiph.org/releases/opus/opus-${OPUS_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
         make && \
@@ -95,9 +94,9 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libvorbis
-        curl -sL http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz | tar zxf - -C . && \
-        cd libvorbis-${VORBIS_VERSION} && \
+#libvorbis https://xiph.org/vorbis/
+        curl -sL http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
         --disable-shared --datadir="${DIR}" && \
         make && \
@@ -105,9 +104,9 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libtheora
-        curl -sL http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.bz2 | tar jxvf - -C . && \
-        cd libtheora-${THEORA_VERSION} && \
+#libtheora http://www.theora.org/
+        curl -sL http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.bz2 | \
+        tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --with-ogg="${SRC}" --bindir="${SRC}/bin" \
         --disable-shared --datadir="${DIR}" && \
         make && \
@@ -115,27 +114,27 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libvpx
-        curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | tar zxf - -C . && \
-        cd libvpx-${VPX_VERSION} && \
+#libvpx https://www.webmproject.org/code/
+        curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --enable-vp8 --enable-vp9 --disable-examples --disable-docs && \
         make && \
         make install && \
         make clean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# libmp3lame
-        curl -Ls https://downloads.sf.net/project/lame/lame/${LAME_VERSION%.*}/lame-${LAME_VERSION}.tar.gz | tar zxf - -C . && \
-        cd lame-${LAME_VERSION} && \
+#libmp3lame http://lame.sourceforge.net/
+        curl -Ls https://downloads.sf.net/project/lame/lame/${LAME_VERSION%.*}/lame-${LAME_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --disable-shared --enable-nasm --datadir="${DIR}" && \
         make && \
         make install && \
-        make distclean && \
+        make distclean&& \
         rm -rf ${DIR} && \
-        DIR=$(mktemp -d) &&  cd ${DIR} && \
-# faac + http://stackoverflow.com/a/4320377
-        curl -Lss https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | tar zxf - -C . && \
-        cd faac-${FAAC_VERSION} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+#faac https://sourceforge.net/projects/faac/ +  http://stackoverflow.com/a/4320377
+        curl -Lss https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         sed -i '126d' common/mp4v2/mpeg4ip.h && \
         ./bootstrap && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \
@@ -143,27 +142,28 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# xvid
-        curl -sL http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | tar zxf - -C . && \
+#xvid https://www.xvid.com/
+        curl -L -s  http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
+        tar -zx && \
         cd xvidcore/build/generic && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \
         make && \
         make install && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# fdk-aac
-        curl -sL https://codeload.github.com/mstorsjo/fdk-aac/tar.gz/v${FDKAAC_VERSION} | tar zxf - -C . && \
-        cd fdk-aac-${FDKAAC_VERSION} && \
+#fdk-aac https://github.com/mstorsjo/fdk-aac
+        curl -sL https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
         make && \
         make install && \
         make distclean && \
-        rm -rf ${DIR}&& \
+        rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
-# ffmpeg
-        curl -sL http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | tar zxf - -C . && \
-        cd ffmpeg-${FFMPEG_VERSION} && \
+## ffmpeg https://ffmpeg.org/
+        curl -sL http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
         ./configure --prefix="${SRC}" \
         --extra-cflags="-I${SRC}/include" \
         --extra-ldflags="-L${SRC}/lib" \
@@ -196,6 +196,7 @@ RUN     export MAKEFLAGS="-j$[$(nproc) + 1]" && \
         make qt-faststart && \
         cp qt-faststart ${SRC}/bin && \
         rm -rf ${DIR} && \
+
 # cleanup
         cd && \
         yum history -y undo last && yum clean all && \

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -24,8 +24,9 @@ ENV         FFMPEG_VERSION=3.1.3 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
             VPX_VERSION=1.6.0    \
-            XVID_VERSION=1.3.5   \
+            XVID_VERSION=1.3.4   \
             X265_VERSION=2.0     \
+            X264_VERSION=20160826-2245-stable \
             SRC=/usr/local       \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
@@ -46,7 +47,7 @@ RUN     buildDeps="autoconf \
                    zlib-devel" && \
         export MAKEFLAGS="-j$(($(nproc) + 1))" && \
         echo "${SRC}/lib" > /etc/ld.so.conf.d/libc.conf && \
-        yum install -y  && \
+        yum install -y ${buildDeps} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
 # yasm http://yasm.tortall.net/
         curl -sL https://github.com/yasm/yasm/archive/v${YASM_VERSION}.tar.gz | \
@@ -59,7 +60,7 @@ RUN     buildDeps="autoconf \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
 # x264 http://www.videolan.org/developers/x264.html TODO : pin version, at least we use the stable branch
-        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/${X264_VERSION}_x264.tar.bz2 | \
+        curl -s ftp://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
         tar -jx --strip-components=1 && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --enable-static && \
         make && \
@@ -133,7 +134,7 @@ RUN     buildDeps="autoconf \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
 #faac https://sourceforge.net/projects/faac/ +  http://stackoverflow.com/a/4320377
-        curl -Lss https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
+        curl -sL https://downloads.sf.net/faac/faac-${FAAC_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
         sed -i '126d' common/mp4v2/mpeg4ip.h && \
         ./bootstrap && \
@@ -143,7 +144,7 @@ RUN     buildDeps="autoconf \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
 #xvid https://www.xvid.com/
-        curl -L -s  http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
+        curl -sL http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz | \
         tar -zx && \
         cd xvidcore/build/generic && \
         ./configure --prefix="${SRC}" --bindir="${SRC}/bin" --datadir="${DIR}" && \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ bash-4.1# for i in yasm x264 x265 ogg opus theora vorbis vpx mp3lame faac xvid f
 Keep uptodate
 -------------
 
--	FFMPEG_VERSION 3.1.2 https://github.com/FFmpeg/FFmpeg/blob/master/Changelog
+-	FFMPEG_VERSION 3.1.3 https://github.com/FFmpeg/FFmpeg/blob/master/Changelog
 -	YASM_VERSION 1.3.0 https://github.com/yasm/yasm/releases
 -	OGG_VERSION 1.3.2 https://xiph.org/downloads/
 -	VORBIS_VERSION 1.3.5 https://xiph.org/downloads/
@@ -108,6 +108,7 @@ Keep uptodate
 -	OPUS_VERSION 1.1.1 https://www.opus-codec.org/downloads/
 -	FAAC_VERSION 1.28 http://www.audiocoding.com/downloads.html
 -	VPX_VERSION 1.6.0 https://github.com/webmproject/libvpx/releases
--	XVID_VERSION 1.3.4 https://labs.xvid.com/source/
+-	XVID_VERSION 1.3.5 https://labs.xvid.com/source/
 -	FDKAAC_VERSION 0.1.4 https://github.com/mstorsjo/fdk-aac/releases
--	X265_VERSION 1.9 https://bitbucket.org/multicoreware/x265/downloads
+-	X265_VERSION 2.0 https://bitbucket.org/multicoreware/x265/downloads
+-   X2654_VERSION latest_stable http://www.videolan.org/developers/x264.html


### PR DESCRIPTION
Add support of X265 multilib (ie. 8bits, 10bits and 12bits).

```
docker run -it -v $PWD:/tmp/workdir ade6e7dca1be -stats -t 00:00:10  -i /tmp/workdir/tearsofsteel_4k.mov -c:v:0 libx265 -pix_fmt yuv420p12 -preset slow -an -dn -sn -f mp4 test_12bits.mp4

ffprobe -hide_banner test_12bits.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'test_12bits.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2mp41
    encoder         : Lavf57.41.100
  Duration: 00:00:10.00, start: 0.000000, bitrate: 2518 kb/s
    Stream #0:0(eng): Video: hevc (Rext) (hev1 / 0x31766568), yuv420p12le(tv, bt2020nc/bt2020/smpte2084), 3840x1714 [SAR 1:1 DAR 1920:857], 2514 kb/s, 24 fps, 24 tbr, 12288 tbn, 24 tbc (default)
    Metadata:
      handler_name    : VideoHandler


```