### PR TITLE
Fix #10 - Addition of Speex - Updated latest ffmpeg 3.1

### DIFF
--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=2.8.8 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -92,6 +93,16 @@ RUN      buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -183,6 +194,7 @@ RUN      buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/2.8/centos/Dockerfile
+++ b/2.8/centos/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=2.8.8 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -91,6 +92,16 @@ RUN     buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -182,6 +193,7 @@ RUN     buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=3.0.3 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -92,6 +93,16 @@ RUN      buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -183,6 +194,7 @@ RUN      buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/3.0/centos/Dockerfile
+++ b/3.0/centos/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=3.0.3 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -91,6 +92,16 @@ RUN     buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -182,6 +193,7 @@ RUN     buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=3.1.4 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -92,6 +93,16 @@ RUN      buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -183,6 +194,7 @@ RUN      buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/3.1/centos/Dockerfile
+++ b/3.1/centos/Dockerfile
@@ -20,6 +20,7 @@ ENV         FFMPEG_VERSION=3.1.4 \
             LAME_VERSION=3.99.5  \
             OGG_VERSION=1.3.2    \
             OPUS_VERSION=1.1.1   \
+            SPEEX_VERSION=1.2rc1 \
             THEORA_VERSION=1.1.1 \
             YASM_VERSION=1.3.0   \
             VORBIS_VERSION=1.3.5 \
@@ -91,6 +92,16 @@ RUN     buildDeps="autoconf \
         tar -zx --strip-components=1 && \
         autoreconf -fiv && \
         ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
         make && \
         make install && \
         make distclean && \
@@ -182,6 +193,7 @@ RUN     buildDeps="autoconf \
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/Dockerfile-env
+++ b/Dockerfile-env
@@ -4,6 +4,7 @@ FFMPEG_VERSION=%%FFMPEG_VERSION%% \\\
             LAME_VERSION=3.99.5  \\\
             OGG_VERSION=1.3.2    \\\
             OPUS_VERSION=1.1.1   \\\
+            SPEEX_VERSION=1.2rc1 \\\
             THEORA_VERSION=1.1.1 \\\
             YASM_VERSION=1.3.0   \\\
             VORBIS_VERSION=1.3.5 \\\

--- a/Dockerfile-run
+++ b/Dockerfile-run
@@ -45,6 +45,16 @@
         make distclean && \
         rm -rf ${DIR} && \
         DIR=$(mktemp -d) && cd ${DIR} && \
+## libspeex http://speex.org/
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar zxf - -C . && \
+        cd speex-${SPEEX_VERSION} && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+        DIR=$(mktemp -d) && cd ${DIR} && \
 ## libvorbis https://xiph.org/vorbis/
         curl -sL http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz | \
         tar -zx --strip-components=1 && \
@@ -131,6 +141,7 @@
         --enable-libvpx \
         --enable-libx264 \
         --enable-libx265 \
+        --enable-libspeex \
         --enable-libxvid \
         --enable-gpl \
         --enable-avresample \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Test
 ```
 ffmpeg version 3.0 Copyright (c) 2000-2016 the FFmpeg developers
   built with gcc 4.8.5 (GCC) 20150623 (Red Hat 4.8.5-4)
-  configuration: --prefix=/usr/local --extra-cflags=-I/usr/local/include --extra-ldflags=-L/usr/local/lib --bindir=/usr/local/bin --extra-libs=-ldl --enable-version3 --enable-libfaac --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-gpl --enable-postproc --enable-nonfree --enable-avresample --enable-libfdk_aac --disable-debug --enable-small --enable-openssl --enable-libtheora --enable-libx265 --enable-libopus --enable-libvorbis --enable-libvpx
+  configuration: --prefix=/usr/local --extra-cflags=-I/usr/local/include --extra-ldflags=-L/usr/local/lib --bindir=/usr/local/bin --extra-libs=-ldl --enable-version3 --enable-libfaac --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-gpl --enable-postproc --enable-nonfree --enable-avresample --enable-libfdk_aac --disable-debug --enable-small --enable-openssl --enable-libtheora --enable-libx265 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libspeex
   libavutil      55. 17.103 / 55. 17.103
   libavcodec     57. 24.102 / 57. 24.102
   libavformat    57. 25.100 / 57. 25.100
@@ -67,6 +67,7 @@ ffmpeg version 3.0 Copyright (c) 2000-2016 the FFmpeg developers
     --enable-libtheora
     --enable-libx265
     --enable-libopus
+    --enable-libspeex
     --enable-libvorbis
     --enable-libvpx
 ```
@@ -110,6 +111,7 @@ See Dockerfile ENV
 - THEORA_VERSION 1.1.1 https://xiph.org/downloads/
 - LAME_VERSION 3.99.5 http://lame.sourceforge.net/download.php
 - OPUS_VERSION 1.1.1 https://www.opus-codec.org/downloads/
+- SPEEX_VERSION 1.2rc1 https://github.com/xiph/speex/
 - FAAC_VERSION 1.28 http://www.audiocoding.com/downloads.html
 - VPX_VERSION 1.6.0 https://github.com/webmproject/libvpx/releases
 - XVID_VERSION 1.3.5 https://labs.xvid.com/source/


### PR DESCRIPTION
Mistakenly opened.  Disregard (we've established this repo doesn't observe `speex`).
