### PR TITLE
Integrating FreeType

### DIFF
--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=2.8.11     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN      buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/2.8/alpine/Dockerfile
+++ b/2.8/alpine/Dockerfile
@@ -24,6 +24,7 @@ ENV         FFMPEG_VERSION=2.8.11     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -33,6 +34,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -167,6 +169,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -185,6 +198,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/2.8/centos/Dockerfile
+++ b/2.8/centos/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=2.8.11     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.0.7     \
+ENV         FFMPEG_VERSION=3.0.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.0.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN      buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.0/alpine/Dockerfile
+++ b/3.0/alpine/Dockerfile
@@ -12,7 +12,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.0.7     \
+ENV         FFMPEG_VERSION=3.0.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -24,6 +24,7 @@ ENV         FFMPEG_VERSION=3.0.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -33,6 +34,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -167,6 +169,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -185,6 +198,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.0/centos/Dockerfile
+++ b/3.0/centos/Dockerfile
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.0.7     \
+ENV         FFMPEG_VERSION=3.0.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.0.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.1.7     \
+ENV         FFMPEG_VERSION=3.1.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.1.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN      buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.1/alpine/Dockerfile
+++ b/3.1/alpine/Dockerfile
@@ -12,7 +12,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.1.7     \
+ENV         FFMPEG_VERSION=3.1.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -24,6 +24,7 @@ ENV         FFMPEG_VERSION=3.1.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -33,6 +34,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -167,6 +169,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -185,6 +198,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.1/centos/Dockerfile
+++ b/3.1/centos/Dockerfile
@@ -14,7 +14,7 @@ ENTRYPOINT  ["ffmpeg"]
 WORKDIR     /tmp/workdir
 
 
-ENV         FFMPEG_VERSION=3.1.7     \
+ENV         FFMPEG_VERSION=3.1.8     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.99.5       \
             OGG_VERSION=1.3.2         \
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.1.7     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.2.5     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN      buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -24,6 +24,7 @@ ENV         FFMPEG_VERSION=3.2.5     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -33,6 +34,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -167,6 +169,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -185,6 +198,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.2/centos/Dockerfile
+++ b/3.2/centos/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.2.5     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.3.1     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN      buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN      buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.3/alpine/Dockerfile
+++ b/3.3/alpine/Dockerfile
@@ -24,6 +24,7 @@ ENV         FFMPEG_VERSION=3.3.1     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -33,6 +34,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -167,6 +169,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -185,6 +198,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/3.3/centos/Dockerfile
+++ b/3.3/centos/Dockerfile
@@ -26,6 +26,7 @@ ENV         FFMPEG_VERSION=3.3.1     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -35,6 +36,7 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"
 
 
@@ -169,6 +171,17 @@ RUN     buildDeps="autoconf \
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -187,6 +200,7 @@ RUN     buildDeps="autoconf \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/Dockerfile-env
+++ b/Dockerfile-env
@@ -10,6 +10,7 @@ FFMPEG_VERSION=%%FFMPEG_VERSION%%     \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
+            FREETYPE_VERSION=2.5.5    \
             PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
             SRC=/usr/local
 
@@ -19,4 +20,5 @@ ARG         OPUS_SHA256SUM="9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1db
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"
+ARG         FREETYPE_SHA256SUM="5d03dd76c2171a7601e9ce10551d52d4471cf92cd205948e60289251daddffa8  freetype-2.5.5.tar.gz"
 ARG         FFMPEG_KEY="D67658D8"

--- a/Dockerfile-run
+++ b/Dockerfile-run
@@ -109,6 +109,17 @@
         make distclean && \
         rm -rf ${DIR} && \
 #RUN  \
+## freetype https://www.freetype.org/
+        DIR=$(mktemp -d) && cd ${DIR} && \
+        curl -sLO http://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --disable-static --enable-shared && \
+        make && \
+        make install && \
+        make distclean && \
+        rm -rf ${DIR} && \
+#RUN  \
 ## ffmpeg https://ffmpeg.org/
         DIR=$(mktemp -d) && cd ${DIR} && \
         gpg --keyserver pool.sks-keyservers.net --recv-keys ${FFMPEG_KEY} && \
@@ -127,6 +138,7 @@
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
         --enable-libfdk_aac \
+        --enable-libfreetype \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libtheora \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ ffmpeg version 3.0 Copyright (c) 2000-2016 the FFmpeg developers
     --enable-libopus
     --enable-libvorbis
     --enable-libvpx
+    --enable-libfreetype
 ```
 
 Capture output from the container to the host running the command
@@ -119,6 +120,7 @@ See Dockerfile-env to update a version
 - [VPX_VERSION](https://github.com/webmproject/libvpx/releases)
 - [XVID_VERSION](https://labs.xvid.com/source/)
 - [FDKAAC_VERSION](https://github.com/mstorsjo/fdk-aac/releases)
+- [FREETYPE_VERSION](http://download.savannah.gnu.org/releases/freetype/)
 - [X264_VERSION](http://www.videolan.org/developers/x264.html)
 - [X265_VERSION](https://bitbucket.org/multicoreware/x265/downloads/)
 


### PR DESCRIPTION
Adding the Freetype Lib to FFMPEG
```
Ex: 
docker run -it --rm \
	-v $(pwd):/tmp/workdir jrottenberg/ffmpeg \
	-f lavfi \
	-i color=c=black:s=1280x720:d=2 \
	-vf "drawtext=fontfile=./assets/fonts/Font.ttf: \
	fontsize=30:fontcolor=white:x=(w-text_w)/2: \
	y=(h-text_h)/2:text='Hello World!'" \
	./output/test.mp4 

```
