### PR TITLE
Install dependencies in the first pass

### DIFF
--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -8,7 +8,7 @@
 FROM        ubuntu:16.04 AS base
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates && \
+        apt-get install -yq --no-install-recommends ca-certificates libgomp1 libexpat1-dev && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -55,7 +55,6 @@ RUN      buildDeps="autoconf \
                     cmake \
                     curl \
                     bzip2 \
-                    libexpat1-dev \
                     g++ \
                     gcc \
                     git \


### PR DESCRIPTION
Fixes #56. @GnaphronG Please confirm me this PR is ok and I'll apply the fix to other variants.

--------------

The bug:

```
~/p/ffmpeg> docker run -it ffmpeg-fixed-4
root@ec751a3d68b4:/# ffmpeg
ffmpeg: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
root@ec751a3d68b4:/# ldd /usr/local/bin/ffmpeg
	linux-vdso.so.1 =>  (0x00007ffe5f38f000)
	libavdevice.so.57 => /usr/local/lib/libavdevice.so.57 (0x00007fe43bc53000)
	libavfilter.so.6 => /usr/local/lib/libavfilter.so.6 (0x00007fe43b858000)
	libavformat.so.57 => /usr/local/lib/libavformat.so.57 (0x00007fe43b49b000)
	libavcodec.so.57 => /usr/local/lib/libavcodec.so.57 (0x00007fe43a1a0000)
	libavresample.so.3 => /usr/local/lib/libavresample.so.3 (0x00007fe439f83000)
	libpostproc.so.54 => /usr/local/lib/libpostproc.so.54 (0x00007fe439d6f000)
	libswresample.so.2 => /usr/local/lib/libswresample.so.2 (0x00007fe439b55000)
	libswscale.so.4 => /usr/local/lib/libswscale.so.4 (0x00007fe4398e0000)
	libavutil.so.55 => /usr/local/lib/libavutil.so.55 (0x00007fe43968b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fe439382000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fe439165000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe438d9b000)
	libvidstab.so.1.1 => /usr/local/lib/libvidstab.so.1.1 (0x00007fe438b86000)
	libfreetype.so.6 => /usr/local/lib/libfreetype.so.6 (0x00007fe4388f0000)
	libass.so.9 => /usr/local/lib/libass.so.9 (0x00007fe4386c1000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fe4384a7000)
	libxvidcore.so.4 => /usr/local/lib/libxvidcore.so.4 (0x00007fe438192000)
	libx265.so.110 => /usr/local/lib/libx265.so.110 (0x00007fe43711f000)
	libx264.so.148 => /usr/local/lib/libx264.so.148 (0x00007fe436d79000)
	libvpx.so.4 => /usr/local/lib/libvpx.so.4 (0x00007fe43694a000)
	libvorbisenc.so.2 => /usr/local/lib/libvorbisenc.so.2 (0x00007fe43669d000)
	libvorbis.so.0 => /usr/local/lib/libvorbis.so.0 (0x00007fe436464000)
	libtheoraenc.so.1 => /usr/local/lib/libtheoraenc.so.1 (0x00007fe436220000)
	libtheoradec.so.1 => /usr/local/lib/libtheoradec.so.1 (0x00007fe436004000)
	libopus.so.0 => /usr/local/lib/libopus.so.0 (0x00007fe435db3000)
	libopenjp2.so.7 => /usr/local/lib/libopenjp2.so.7 (0x00007fe435b63000)
	libopencore-amrwb.so.0 => /usr/local/lib/libopencore-amrwb.so.0 (0x00007fe43594f000)
	libopencore-amrnb.so.0 => /usr/local/lib/libopencore-amrnb.so.0 (0x00007fe435725000)
	libmp3lame.so.0 => /usr/local/lib/libmp3lame.so.0 (0x00007fe435468000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fe435264000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fe43be61000)
	libgomp.so.1 => not found
	libfribidi.so.0 => /usr/local/lib/libfribidi.so.0 (0x00007fe43504b000)
	libfontconfig.so.1 => /usr/local/lib/libfontconfig.so.1 (0x00007fe434e07000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fe434a85000)
	libogg.so.0 => /usr/local/lib/libogg.so.0 (0x00007fe43487e000)
	libexpat.so.1 => not found
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fe434668000)
```

Both `not-found` where previously installed in the first `RUN apt-get install`.
While running a bash command within the container and issuing a `apt-get install -y libgomp1 libexpat1-dev` make `ffmpeg` work.

So my best bet was to put back these two in the first RUN of apt-get install.
Unfortunatly, I have no explanation as of why this is the solution... @GnaphronG Any reason expat was moved to `buildDeps` and libgomp1 removed from the requirements? Could `ARG LD_LIBRARY_PATH=/opt/ffmpeg/lib` causes a problem for subsequent library installs?