### PR TITLE
no more ftp with proper ssl there

### DIFF
--- a/templates/Dockerfile-run
+++ b/templates/Dockerfile-run
@@ -14,7 +14,7 @@ RUN \
         DIR=/tmp/x264 && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
-        curl -sL https://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
+        curl -sL https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
         tar -jx --strip-components=1 && \
         ./configure --prefix="${PREFIX}" --enable-shared --enable-pic --disable-cli && \
         make && \


### PR DESCRIPTION
download vhost is clean, and is cleaner anyway, already used for x265...