### PR TITLE
Removing repeated configure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Test
 ```
 ffmpeg version 3.3.4 Copyright (c) 2000-2017 the FFmpeg developers
   built with gcc 5.4.0 (Ubuntu 5.4.0-6ubuntu1~16.04.4) 20160609
-  configuration: --disable-debug --disable-doc --disable-ffplay --enable-shared --enable-avresample --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-gpl --enable-libass --enable-libfreetype --enable-libvidstab --enable-libmp3lame --enable-libopenjpeg --enable-libopus --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx265 --enable-libxvid --enable-gpl --enable-libx264 --enable-nonfree --enable-openssl --enable-libfdk_aac --enable-postproc --enable-small --enable-version3 --extra-cflags=-I/opt/ffmpeg/include --extra-ldflags=-L/opt/ffmpeg/lib --extra-libs=-ldl --prefix=/opt/ffmpeg
+  configuration: --disable-debug --disable-doc --disable-ffplay --enable-shared --enable-avresample --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-gpl --enable-libass --enable-libfreetype --enable-libvidstab --enable-libmp3lame --enable-libopenjpeg --enable-libopus --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx265 --enable-libxvid --enable-libx264 --enable-nonfree --enable-openssl --enable-libfdk_aac --enable-postproc --enable-small --enable-version3 --extra-cflags=-I/opt/ffmpeg/include --extra-ldflags=-L/opt/ffmpeg/lib --extra-libs=-ldl --prefix=/opt/ffmpeg
   libavutil      55. 58.100 / 55. 58.100
   libavcodec     57. 89.100 / 57. 89.100
   libavformat    57. 71.100 / 57. 71.100
@@ -72,7 +72,6 @@ ffmpeg version 3.3.4 Copyright (c) 2000-2017 the FFmpeg developers
     --enable-libvpx
     --enable-libx265
     --enable-libxvid
-    --enable-gpl
     --enable-libx264
     --enable-nonfree
     --enable-openssl

--- a/docker-images/2.8/Dockerfile
+++ b/docker-images/2.8/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/2.8/alpine/Dockerfile
+++ b/docker-images/2.8/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/2.8/centos/Dockerfile
+++ b/docker-images/2.8/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/2.8/scratch/Dockerfile
+++ b/docker-images/2.8/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.0/Dockerfile
+++ b/docker-images/3.0/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.0/alpine/Dockerfile
+++ b/docker-images/3.0/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.0/centos/Dockerfile
+++ b/docker-images/3.0/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.0/scratch/Dockerfile
+++ b/docker-images/3.0/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.1/Dockerfile
+++ b/docker-images/3.1/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.1/alpine/Dockerfile
+++ b/docker-images/3.1/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.1/centos/Dockerfile
+++ b/docker-images/3.1/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.1/scratch/Dockerfile
+++ b/docker-images/3.1/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.2/Dockerfile
+++ b/docker-images/3.2/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.2/centos/Dockerfile
+++ b/docker-images/3.2/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.3/Dockerfile
+++ b/docker-images/3.3/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.3/centos/Dockerfile
+++ b/docker-images/3.3/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.4/Dockerfile
+++ b/docker-images/3.4/Dockerfile
@@ -304,7 +304,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -301,7 +301,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.4/centos/Dockerfile
+++ b/docker-images/3.4/centos/Dockerfile
@@ -303,7 +303,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -297,7 +297,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \

--- a/templates/Dockerfile-run
+++ b/templates/Dockerfile-run
@@ -229,7 +229,6 @@ RUN  \
         --enable-libvpx \
         --enable-libx265 \
         --enable-libxvid \
-        --enable-gpl \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \


### PR DESCRIPTION
`--enable-gpl` is repeated in the list of flags. One of them is removed.

I only modified the HEAD. Should the tags be retroactively changed as well?