### PR TITLE
Support sftp:// urls

### DIFF
--- a/docker-images/2.8/Dockerfile
+++ b/docker-images/2.8/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/2.8/alpine/Dockerfile
+++ b/docker-images/2.8/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/2.8/centos/Dockerfile
+++ b/docker-images/2.8/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/2.8/scratch/Dockerfile
+++ b/docker-images/2.8/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.0/Dockerfile
+++ b/docker-images/3.0/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.0/alpine/Dockerfile
+++ b/docker-images/3.0/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.0/centos/Dockerfile
+++ b/docker-images/3.0/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.0/scratch/Dockerfile
+++ b/docker-images/3.0/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.1/Dockerfile
+++ b/docker-images/3.1/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.1/alpine/Dockerfile
+++ b/docker-images/3.1/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.1/centos/Dockerfile
+++ b/docker-images/3.1/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.1/scratch/Dockerfile
+++ b/docker-images/3.1/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.2/Dockerfile
+++ b/docker-images/3.2/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.2/centos/Dockerfile
+++ b/docker-images/3.2/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.3/Dockerfile
+++ b/docker-images/3.3/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.3/centos/Dockerfile
+++ b/docker-images/3.3/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.4/Dockerfile
+++ b/docker-images/3.4/Dockerfile
@@ -69,6 +69,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -307,6 +308,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \
@@ -304,6 +305,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.4/centos/Dockerfile
+++ b/docker-images/3.4/centos/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \
@@ -306,6 +307,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -61,6 +61,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \
@@ -300,6 +301,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/templates/Dockerfile-run
+++ b/templates/Dockerfile-run
@@ -232,6 +232,7 @@ RUN  \
         --enable-libx264 \
         --enable-nonfree \
         --enable-openssl \
+        --enable-libssh \
         --enable-libfdk_aac \
         --enable-postproc \
         --enable-small \

--- a/templates/Dockerfile-template.alpine
+++ b/templates/Dockerfile-template.alpine
@@ -36,6 +36,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev \

--- a/templates/Dockerfile-template.centos
+++ b/templates/Dockerfile-template.centos
@@ -36,6 +36,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    openssl-devel \
+                   libssh-devel \
                    tar \
                    yasm \
                    which \

--- a/templates/Dockerfile-template.scratch
+++ b/templates/Dockerfile-template.scratch
@@ -32,6 +32,7 @@ RUN     buildDeps="autoconf \
                    make \
                    python \
                    openssl-dev \
+                   libssh-dev \
                    tar \
                    yasm \
                    zlib-dev" && \

--- a/templates/Dockerfile-template.ubuntu
+++ b/templates/Dockerfile-template.ubuntu
@@ -40,6 +40,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \


### PR DESCRIPTION
Enable SFTP (Secure File Transfer) for input and output through libssh.

`sftp://[user[:password]@]server[:port]/path/to/remote/resource.mpeg`

See https://ffmpeg.org/ffmpeg-protocols.html#libssh