### PR TITLE
Use Ubuntu 18.04 (Bionic) as the base image for the VA-API images

### DIFF
--- a/docker-images/2.8/vaapi/Dockerfile
+++ b/docker-images/2.8/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:18.04 AS base
+FROM        ubuntu:16.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/2.8/vaapi/Dockerfile
+++ b/docker-images/2.8/vaapi/Dockerfile
@@ -372,7 +372,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/2.8/vaapi/Dockerfile
+++ b/docker-images/2.8/vaapi/Dockerfile
@@ -372,7 +372,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/2.8/vaapi/Dockerfile
+++ b/docker-images/2.8/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -372,7 +372,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.0/vaapi/Dockerfile
+++ b/docker-images/3.0/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:18.04 AS base
+FROM        ubuntu:16.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.0/vaapi/Dockerfile
+++ b/docker-images/3.0/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.0/vaapi/Dockerfile
+++ b/docker-images/3.0/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.0/vaapi/Dockerfile
+++ b/docker-images/3.0/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.1/vaapi/Dockerfile
+++ b/docker-images/3.1/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:18.04 AS base
+FROM        ubuntu:16.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.1/vaapi/Dockerfile
+++ b/docker-images/3.1/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.1/vaapi/Dockerfile
+++ b/docker-images/3.1/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.1/vaapi/Dockerfile
+++ b/docker-images/3.1/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:18.04 AS base
+FROM        ubuntu:16.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.3/vaapi/Dockerfile
+++ b/docker-images/3.3/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.3/vaapi/Dockerfile
+++ b/docker-images/3.3/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.4/vaapi/Dockerfile
+++ b/docker-images/3.4/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.4/vaapi/Dockerfile
+++ b/docker-images/3.4/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/snapshot/vaapi/Dockerfile
+++ b/docker-images/snapshot/vaapi/Dockerfile
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/snapshot/vaapi/Dockerfile
+++ b/docker-images/snapshot/vaapi/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -373,7 +373,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/templates/Dockerfile-template.vaapi
+++ b/templates/Dockerfile-template.vaapi
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -64,7 +64,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/templates/Dockerfile-template.vaapi
+++ b/templates/Dockerfile-template.vaapi
@@ -64,7 +64,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/update.py
+++ b/update.py
@@ -73,6 +73,8 @@ for version in keep_version:
         # FFmpeg 3.2 and earlier don't compile correctly on Ubuntu 18.04 due to openssl issues
         if variant == 'vaapi' and (version[0] < '3' or (version[0] == '3' and version[2] < '3')):
             docker_content = docker_content.replace('ubuntu:18.04', 'ubuntu:16.04')
+            docker_content = docker_content.replace('libva-drm2', 'libva-drm1')
+            docker_content = docker_content.replace('libva2', 'libva1')
 
         d = os.path.dirname(dockerfile)
         if not os.path.exists(d):

--- a/update.py
+++ b/update.py
@@ -70,6 +70,10 @@ for version in keep_version:
         if (version == 'snapshot' or version[0] >= '3') and variant == 'vaapi':
             docker_content = docker_content.replace('--disable-ffplay', '--disable-ffplay \\\n        --enable-vaapi')
 
+        # FFmpeg 3.2 and earlier don't compile correctly on Ubuntu 18.04 due to openssl issues
+        if variant == 'vaapi' and (version[0] < '3' or (version[0] == '3' and version[3] < '3')):
+            docker_content = docker_content.replace('ubuntu:18.04', 'ubuntu:16.04')
+
         d = os.path.dirname(dockerfile)
         if not os.path.exists(d):
             os.makedirs(d)

--- a/update.py
+++ b/update.py
@@ -71,7 +71,7 @@ for version in keep_version:
             docker_content = docker_content.replace('--disable-ffplay', '--disable-ffplay \\\n        --enable-vaapi')
 
         # FFmpeg 3.2 and earlier don't compile correctly on Ubuntu 18.04 due to openssl issues
-        if variant == 'vaapi' and (version[0] < '3' or (version[0] == '3' and version[3] < '3')):
+        if variant == 'vaapi' and (version[0] < '3' or (version[0] == '3' and version[2] < '3')):
             docker_content = docker_content.replace('ubuntu:18.04', 'ubuntu:16.04')
 
         d = os.path.dirname(dockerfile)


### PR DESCRIPTION
Newer versions of Ubuntu ship with newer versions of the Intel va-api drivers. For example, version 2.0 of the drivers added support for VBR encoding, something I'm interested in. Version 2.0 of the driver is available in Ubuntu 18.04. and not in 16.04.

Hence, this PR updates the container to use Ubuntu 18.04 instead of 16.04.

I could do the same for the other Ubuntu-based images if you want to upgrade everything to 18.04.