### PR TITLE
flip version/label so it matches the tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,34 @@ You'll find centos based image using `ffmpeg:X.Y-centos` or `ffmpeg:centos` to g
 alpine images  `ffmpeg:X.Y-alpine` to get the latest.
 scratch images `ffmpeg:X.Y-scratch` to get the latest. (Scratch is an experimental image containing only FFmpeg and libraries)
 
-For information :
+Recent images:
 
 ```
-3.3-centos          centos              28221bb909aa        About an hour ago    264MB
-3.3-ubuntu          ubuntu              d6b632a4fe7f        3 seconds ago        221MB
-3.3-alpine          alpine              725234fc4162        40 minutes ago       65.6MB
-3.3-scratch         scratch             34724534bb88        15 minutes ago       48.6MB
-```
+vaapi               86mb    2018-08-16
+snapshot-centos     95mb    2018-08-16
+snapshot-alpine     27mb    2018-08-16
+4.0-vaapi           86mb    2018-08-15
+4.0-ubuntu          94mb    2018-08-16
+4.0-scratch         20mb    2018-08-16
+4.0-centos          95mb    2018-08-16
+3.4-vaapi           84mb    2018-08-15
+3.4-scratch         18mb    2018-08-16
+3.4-alpine          24mb    2018-08-16
+3.4                 92mb    2018-08-16
+3.3-scratch         17mb    2018-08-04
+3.2-scratch         17mb    2018-08-16
+3.2-alpine          24mb    2018-08-16
+3.0-scratch         17mb    2018-08-16
+3.0-centos          94mb    2018-08-16
+2.8-scratch         16mb    2018-08-16
+2.8                 90mb    2018-08-16
 
+```
+(<details><summary>How the 'recent images' was generated</summary>
+```
+    $ curl --silent https://hub.docker.com/v2/repositories/jrottenberg/ffmpeg/tags/?page_size=500 | jq -cr ".results|sort_by(.name)|reverse[]|.sz=(.full_size/1048576|floor|tostring+\"mb\")|[.name,( (20-(.name|length))*\" \" ),.sz,( (8-(.sz|length))*\" \"),.last_updated[:10]]|@text|gsub(\"[,\\\"\\\]\\\[]\";null)" | grep 2018-08
+```
+</details>)
 
 Please use [Github issues](https://github.com/jrottenberg/ffmpeg/issues/new) to report any bug or missing feature.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ scratch images `ffmpeg:X.Y-scratch` to get the latest. (Scratch is an experiment
 For information :
 
 ```
-centos-3.3          centos              28221bb909aa        About an hour ago    264MB
-ubuntu-3.3          ubuntu              d6b632a4fe7f        3 seconds ago        221MB
-alpine-3.3          alpine              725234fc4162        40 minutes ago       65.6MB
-scratch-3.3         scratch             34724534bb88        15 minutes ago       48.6MB
+3.3-centos          centos              28221bb909aa        About an hour ago    264MB
+3.3-ubuntu          ubuntu              d6b632a4fe7f        3 seconds ago        221MB
+3.3-alpine          alpine              725234fc4162        40 minutes ago       65.6MB
+3.3-scratch         scratch             34724534bb88        15 minutes ago       48.6MB
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ snapshot-alpine     27mb    2018-08-16
 3.0-centos          94mb    2018-08-16
 2.8-scratch         16mb    2018-08-16
 2.8                 90mb    2018-08-16
-
 ```
-(<details><summary>How the 'recent images' was generated</summary>
+
+<details><summary>(How the 'recent images' was generated)</summary>
 ```
     $ curl --silent https://hub.docker.com/v2/repositories/jrottenberg/ffmpeg/tags/?page_size=500 | jq -cr ".results|sort_by(.name)|reverse[]|.sz=(.full_size/1048576|floor|tostring+\"mb\")|[.name,( (20-(.name|length))*\" \" ),.sz,( (8-(.sz|length))*\" \"),.last_updated[:10]]|@text|gsub(\"[,\\\"\\\]\\\[]\";null)" | grep 2018-08
 ```
-</details>)
+</details>
 
 Please use [Github issues](https://github.com/jrottenberg/ffmpeg/issues/new) to report any bug or missing feature.
 


### PR DESCRIPTION
This section kinda feels autogenerated but I didn't see it in the repo.

I think there are also some newer versions, I see "3.4-", "4.0-" and "-vaapi" floating around.