### PR TITLE
Add support for Azure Pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 jobs:
 - job: Build
   pool:
@@ -10,58 +5,139 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      ubuntu_snapshot:
+      snapshot_ubuntu:
         VERSION: snapshot
         VARIANT: ubuntu
-      ubuntu_41:
+      snapshot_alpine:
+        VERSION: snapshot
+        VARIANT: alpine
+      snapshot_centos:
+        VERSION: snapshot
+        VARIANT: centos
+      snapshot_scratch:
+        VERSION: snapshot
+        VARIANT: scratch
+      snapshot_vaapi:
+        VERSION: snapshot
+        VARIANT: vaapi
+      4_1_ubuntu:
         VERSION: 4.1
         VARIANT: ubuntu
-      ubuntu_40:
+      4_1_alpine:
+        VERSION: 4.1
+        VARIANT: alpine
+      4_1_centos:
+        VERSION: 4.1
+        VARIANT: centos
+      4_1_scratch:
+        VERSION: 4.1
+        VARIANT: scratch
+      4_1_vaapi:
+        VERSION: 4.1
+        VARIANT: vaapi
+      4_0_ubuntu:
         VERSION: 4.0
         VARIANT: ubuntu
-      ubuntu_34:
+      4_0_alpine:
+        VERSION: 4.0
+        VARIANT: alpine
+      4_0_centos:
+        VERSION: 4.0
+        VARIANT: centos
+      4_0_scratch:
+        VERSION: 4.0
+        VARIANT: scratch
+      4_0_vaapi:
+        VERSION: 4.0
+        VARIANT: vaapi
+      3_4_ubuntu:
         VERSION: 3.4
         VARIANT: ubuntu
-      ubuntu_33:
+      3_4_alpine:
+        VERSION: 3.4
+        VARIANT: alpine
+      3_4_centos:
+        VERSION: 3.4
+        VARIANT: centos
+      3_4_scratch:
+        VERSION: 3.4
+        VARIANT: scratch
+      3_4_vaapi:
+        VERSION: 3.4
+        VARIANT: vaapi
+      3_3_ubuntu:
         VERSION: 3.3
         VARIANT: ubuntu
-      ubuntu_32:
+      3_3_alpine:
+        VERSION: 3.3
+        VARIANT: alpine
+      3_3_centos:
+        VERSION: 3.3
+        VARIANT: centos
+      3_3_scratch:
+        VERSION: 3.3
+        VARIANT: scratch
+      3_3_vaapi:
+        VERSION: 3.3
+        VARIANT: vaapi
+      3_2_ubuntu:
         VERSION: 3.2
         VARIANT: ubuntu
-      ubuntu_31:
+      3_2_alpine:
+        VERSION: 3.2
+        VARIANT: alpine
+      3_2_centos:
+        VERSION: 3.2
+        VARIANT: centos
+      3_2_scratch:
+        VERSION: 3.2
+        VARIANT: scratch
+      3_2_vaapi:
+        VERSION: 3.2
+        VARIANT: vaapi
+      3_1_ubuntu:
         VERSION: 3.1
         VARIANT: ubuntu
-      ubuntu_30:
+      3_1_alpine:
+        VERSION: 3.1
+        VARIANT: alpine
+      3_1_centos:
+        VERSION: 3.1
+        VARIANT: centos
+      3_1_scratch:
+        VERSION: 3.1
+        VARIANT: scratch
+      3_1_vaapi:
+        VERSION: 3.1
+        VARIANT: vaapi
+      3_0_ubuntu:
         VERSION: 3.0
         VARIANT: ubuntu
-      ubuntu_28:
+      3_0_alpine:
+        VERSION: 3.0
+        VARIANT: alpine
+      3_0_centos:
+        VERSION: 3.0
+        VARIANT: centos
+      3_0_scratch:
+        VERSION: 3.0
+        VARIANT: scratch
+      3_0_vaapi:
+        VERSION: 3.0
+        VARIANT: vaapi
+      2_8_ubuntu:
         VERSION: 2.8
         VARIANT: ubuntu
-      vaapi_snapshot:
-        VERSION: snapshot
-        VARIANT: vaapi
-      vaapi_41:
-        VERSION: 4.1
-        VARIANT: vaapi
-      vaapi_40:
-        VERSION: 4.0
-        VARIANT: vaapi
-      vaapi_34:
-        VERSION: 3.4
-        VARIANT: vaapi
-      vaapi_33:
-        VERSION: 3.3
-        VARIANT: vaapi
-      vaapi_32:
-        VERSION: 3.2
-        VARIANT: vaapi
-      vaapi_31:
-        VERSION: 3.1
-        VARIANT: vaapi
-      vaapi_30:
-        VERSION: 3.0
-        VARIANT: vaapi
-      vaapi_28:
+      2_8_alpine:
+        VERSION: 2.8
+        VARIANT: alpine
+      2_8_centos:
+        VERSION: 2.8
+        VARIANT: centos
+      2_8_scratch:
+        VERSION: 2.8
+        VARIANT: scratch
+      2_8_vaapi:
         VERSION: 2.8
         VARIANT: vaapi
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,69 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+jobs:
+- job: Build
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 10
+    matrix:
+      ubuntu_snapshot:
+        VERSION: snapshot
+        VARIANT: ubuntu
+      ubuntu_41:
+        VERSION: 4.1
+        VARIANT: ubuntu
+      ubuntu_40:
+        VERSION: 4.0
+        VARIANT: ubuntu
+      ubuntu_34:
+        VERSION: 3.4
+        VARIANT: ubuntu
+      ubuntu_33:
+        VERSION: 3.3
+        VARIANT: ubuntu
+      ubuntu_32:
+        VERSION: 3.2
+        VARIANT: ubuntu
+      ubuntu_31:
+        VERSION: 3.1
+        VARIANT: ubuntu
+      ubuntu_30:
+        VERSION: 3.0
+        VARIANT: ubuntu
+      ubuntu_28:
+        VERSION: 2.8
+        VARIANT: ubuntu
+      vaapi_snapshot:
+        VERSION: snapshot
+        VARIANT: vaapi
+      vaapi_41:
+        VERSION: 4.1
+        VARIANT: vaapi
+      vaapi_40:
+        VERSION: 4.0
+        VARIANT: vaapi
+      vaapi_34:
+        VERSION: 3.4
+        VARIANT: vaapi
+      vaapi_33:
+        VERSION: 3.3
+        VARIANT: vaapi
+      vaapi_32:
+        VERSION: 3.2
+        VARIANT: vaapi
+      vaapi_31:
+        VERSION: 3.1
+        VARIANT: vaapi
+      vaapi_30:
+        VERSION: 3.0
+        VARIANT: vaapi
+      vaapi_28:
+        VERSION: 2.8
+        VARIANT: vaapi
+  steps:
+  - script: |
+      docker build -t "ffmpeg:${VERSION}-${VARIANT}" --build-arg MAKEFLAGS="-j$(($(grep -c ^processor /proc/cpuinfo) + 1))" docker-images/${VERSION}/${VARIANT}

--- a/templates/azure.template
+++ b/templates/azure.template
@@ -1,0 +1,11 @@
+jobs:
+- job: Build
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 10
+    matrix:
+%%VERSIONS%%
+  steps:
+  - script: |
+      docker build -t "ffmpeg:${VERSION}-${VARIANT}" --build-arg MAKEFLAGS="-j$(($(grep -c ^processor /proc/cpuinfo) + 1))" docker-images/${VERSION}/${VARIANT}

--- a/update.py
+++ b/update.py
@@ -13,6 +13,7 @@ VARIANTS = ['ubuntu', 'alpine', 'centos', 'scratch', 'vaapi']
 FFMPEG_RELEASES = 'https://ffmpeg.org/releases/'
 
 travis = []
+azure = []
 response = urllib2.urlopen(FFMPEG_RELEASES)
 ffmpeg_releases = response.read()
 
@@ -47,10 +48,12 @@ for version in keep_version:
             dockerfile = 'docker-images/%s/%s/Dockerfile' % (
                 version, variant)
             travis.append(' - VERSION=%s VARIANT=%s' % (version, variant))
+            azure.append('      %s_%s:\n        VERSION: %s\n        VARIANT: %s' % (version.replace('.', '_'), variant, version, variant))
         else:
             dockerfile = 'docker-images/%s/%s/Dockerfile' % (
                 version[0:3], variant)
             travis.append(' - VERSION=%s VARIANT=%s' % (version[0:3], variant))
+            azure.append('      %s_%s:\n        VERSION: %s\n        VARIANT: %s' % (version[0:3].replace('.', '_'), variant, version[0:3], variant))
 
         with open('templates/Dockerfile-env', 'r') as tmpfile:
             env_content = tmpfile.read()
@@ -85,3 +88,11 @@ travis = template.replace('%%VERSIONS%%', '\n'.join(travis))
 
 with open('.travis.yml', 'w') as travisfile:
     travisfile.write(travis)
+
+with open('templates/azure.template', 'r') as tmpfile:
+    template = tmpfile.read()
+azure = template.replace('%%VERSIONS%%', '\n'.join(azure))
+
+
+with open('azure-pipelines.yml', 'w') as azurefile:
+    azurefile.write(azure)


### PR DESCRIPTION
The CI process for this repository is a bit slow :).

This PR adds a template for building with Azure Pipelines.
Azure Pipelines gets you free CI for open source projects, with up to 10 parallel jobs (compared to 5 in Travis). The individual builds also appear to be a bit faster.

Here's an example of the build: https://dev.azure.com/qmfrederik/FFmpeg/_build/results?buildId=105&view=logs

You can also consider 'load balancing' the builds across Azure & Travis. That would get you 15 parallel jobs.
