### PR TITLE
Upgrade to LAME 3.100

### DIFF
--- a/docker-images/2.8/alpine/Dockerfile
+++ b/docker-images/2.8/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=2.8.15     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/2.8/centos/Dockerfile
+++ b/docker-images/2.8/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=2.8.15     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/2.8/scratch/Dockerfile
+++ b/docker-images/2.8/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=2.8.15     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/2.8/ubuntu/Dockerfile
+++ b/docker-images/2.8/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=2.8.15     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/2.8/vaapi/Dockerfile
+++ b/docker-images/2.8/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=2.8.15     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.0/alpine/Dockerfile
+++ b/docker-images/3.0/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.0.12     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.0/centos/Dockerfile
+++ b/docker-images/3.0/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.0.12     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.0/scratch/Dockerfile
+++ b/docker-images/3.0/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.0.12     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.0/ubuntu/Dockerfile
+++ b/docker-images/3.0/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.0.12     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.0/vaapi/Dockerfile
+++ b/docker-images/3.0/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.0.12     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.1/alpine/Dockerfile
+++ b/docker-images/3.1/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.1.11     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.1/centos/Dockerfile
+++ b/docker-images/3.1/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.1.11     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.1/scratch/Dockerfile
+++ b/docker-images/3.1/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.1.11     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.1/ubuntu/Dockerfile
+++ b/docker-images/3.1/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.1.11     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.1/vaapi/Dockerfile
+++ b/docker-images/3.1/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.1.11     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.2.13     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.2/centos/Dockerfile
+++ b/docker-images/3.2/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.2.13     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.2.13     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.2/ubuntu/Dockerfile
+++ b/docker-images/3.2/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.2.13     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.2.13     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.3.9     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.3/centos/Dockerfile
+++ b/docker-images/3.3/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.3.9     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.3.9     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.3/ubuntu/Dockerfile
+++ b/docker-images/3.3/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.3.9     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.3/vaapi/Dockerfile
+++ b/docker-images/3.3/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.3.9     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.4.5     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.4/centos/Dockerfile
+++ b/docker-images/3.4/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.4.5     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.4.5     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.4/ubuntu/Dockerfile
+++ b/docker-images/3.4/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.4.5     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/3.4/vaapi/Dockerfile
+++ b/docker-images/3.4/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=3.4.5     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.0/alpine/Dockerfile
+++ b/docker-images/4.0/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.0.3     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.0/centos/Dockerfile
+++ b/docker-images/4.0/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.0.3     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.0.3     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.0/ubuntu/Dockerfile
+++ b/docker-images/4.0/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.0.3     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.0.3     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.1.2     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.1/centos/Dockerfile
+++ b/docker-images/4.1/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.1.2     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.1.2     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.1.2     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/4.1/vaapi/Dockerfile
+++ b/docker-images/4.1/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=4.1.2     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/snapshot/alpine/Dockerfile
+++ b/docker-images/snapshot/alpine/Dockerfile
@@ -20,7 +20,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=snapshot     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/snapshot/centos/Dockerfile
+++ b/docker-images/snapshot/centos/Dockerfile
@@ -22,7 +22,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=snapshot     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/snapshot/scratch/Dockerfile
+++ b/docker-images/snapshot/scratch/Dockerfile
@@ -15,7 +15,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=snapshot     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/snapshot/ubuntu/Dockerfile
+++ b/docker-images/snapshot/ubuntu/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=snapshot     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/docker-images/snapshot/vaapi/Dockerfile
+++ b/docker-images/snapshot/vaapi/Dockerfile
@@ -23,7 +23,7 @@ ARG        MAKEFLAGS="-j2"
 
 ENV         FFMPEG_VERSION=snapshot     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \

--- a/templates/Dockerfile-env
+++ b/templates/Dockerfile-env
@@ -1,6 +1,6 @@
 FFMPEG_VERSION=%%FFMPEG_VERSION%%     \
             FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \


### PR DESCRIPTION
Lame 3.100 was released on 13-nov-2017, over five years after Lame 3.99.