### PR TITLE
Use Alpine 3.8 for building Scratch images

### DIFF
--- a/docker-images/2.8/scratch/Dockerfile
+++ b/docker-images/2.8/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.0/scratch/Dockerfile
+++ b/docker-images/3.0/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.1/scratch/Dockerfile
+++ b/docker-images/3.1/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/snapshot/scratch/Dockerfile
+++ b/docker-images/snapshot/scratch/Dockerfile
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 

--- a/templates/Dockerfile-template.scratch
+++ b/templates/Dockerfile-template.scratch
@@ -4,7 +4,7 @@
 #
 #
 
-FROM        alpine:3.5 AS build
+FROM        alpine:3.8 AS build
 
 WORKDIR     /tmp/workdir
 


### PR DESCRIPTION
Alpine 3.8 is also being used when building the Alpine images. Alpine 3.5 doesn't support arm64, 3.8 does.