### PR TITLE
Updated libraries for ffmpeg 4.1

### DIFF
--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -40,8 +40,8 @@ ENV         FFMPEG_VERSION=4.1.3      \
             AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
-ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9  opus-1.2.tar.gz"
+ARG         OGG_SHA256SUM="c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985  libogg-1.3.3.tar.gz"
+ARG         OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d  opus-1.3.1.tar.gz"
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"

--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -18,19 +18,19 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.1.3     \
-            FDKAAC_VERSION=0.1.5      \
+ENV         FFMPEG_VERSION=4.1.3      \
+            FDKAAC_VERSION=2.0.0      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
-            OGG_VERSION=1.3.2         \
+            OGG_VERSION=1.3.3         \
             OPENCOREAMR_VERSION=0.1.5 \
-            OPUS_VERSION=1.2          \
+            OPUS_VERSION=1.3.1        \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
             VPX_VERSION=1.8.0         \
-            X264_VERSION=20170226-2245-stable \
-            X265_VERSION=2.3          \
+            X264_VERSION=20190419-2245-stable \
+            X265_VERSION=3.0          \
             XVID_VERSION=1.3.4        \
             FREETYPE_VERSION=2.5.5    \
             FRIBIDI_VERSION=0.19.7    \
@@ -70,6 +70,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/4.1/centos/Dockerfile
+++ b/docker-images/4.1/centos/Dockerfile
@@ -42,8 +42,8 @@ ENV         FFMPEG_VERSION=4.1.3      \
             AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
-ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9  opus-1.2.tar.gz"
+ARG         OGG_SHA256SUM="c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985  libogg-1.3.3.tar.gz"
+ARG         OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d  opus-1.3.1.tar.gz"
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"

--- a/docker-images/4.1/centos/Dockerfile
+++ b/docker-images/4.1/centos/Dockerfile
@@ -20,19 +20,19 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.1.3     \
-            FDKAAC_VERSION=0.1.5      \
+ENV         FFMPEG_VERSION=4.1.3      \
+            FDKAAC_VERSION=2.0.0      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
-            OGG_VERSION=1.3.2         \
+            OGG_VERSION=1.3.3         \
             OPENCOREAMR_VERSION=0.1.5 \
-            OPUS_VERSION=1.2          \
+            OPUS_VERSION=1.3.1        \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
             VPX_VERSION=1.8.0         \
-            X264_VERSION=20170226-2245-stable \
-            X265_VERSION=2.3          \
+            X264_VERSION=20190419-2245-stable \
+            X265_VERSION=3.0          \
             XVID_VERSION=1.3.4        \
             FREETYPE_VERSION=2.5.5    \
             FRIBIDI_VERSION=0.19.7    \
@@ -69,6 +69,7 @@ RUN     buildDeps="autoconf \
                    openssl-devel \
                    tar \
                    yasm \
+                   nasm \
                    which \
                    zlib-devel" && \
         echo "${SRC}/lib" > /etc/ld.so.conf.d/libc.conf && \

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -13,19 +13,19 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.1.3     \
-            FDKAAC_VERSION=0.1.5      \
+ENV         FFMPEG_VERSION=4.1.3      \
+            FDKAAC_VERSION=2.0.0      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
-            OGG_VERSION=1.3.2         \
+            OGG_VERSION=1.3.3         \
             OPENCOREAMR_VERSION=0.1.5 \
-            OPUS_VERSION=1.2          \
+            OPUS_VERSION=1.3.1        \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
             VPX_VERSION=1.8.0         \
-            X264_VERSION=20170226-2245-stable \
-            X265_VERSION=2.3          \
+            X264_VERSION=20190419-2245-stable \
+            X265_VERSION=3.0          \
             XVID_VERSION=1.3.4        \
             FREETYPE_VERSION=2.5.5    \
             FRIBIDI_VERSION=0.19.7    \
@@ -66,6 +66,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -35,8 +35,8 @@ ENV         FFMPEG_VERSION=4.1.3      \
             AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
-ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9  opus-1.2.tar.gz"
+ARG         OGG_SHA256SUM="c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985  libogg-1.3.3.tar.gz"
+ARG         OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d  opus-1.3.1.tar.gz"
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -21,19 +21,19 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.1.3     \
-            FDKAAC_VERSION=0.1.5      \
+ENV         FFMPEG_VERSION=4.1.3      \
+            FDKAAC_VERSION=2.0.0      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
-            OGG_VERSION=1.3.2         \
+            OGG_VERSION=1.3.3         \
             OPENCOREAMR_VERSION=0.1.5 \
-            OPUS_VERSION=1.2          \
+            OPUS_VERSION=1.3.1        \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
             VPX_VERSION=1.8.0         \
-            X264_VERSION=20170226-2245-stable \
-            X265_VERSION=2.3          \
+            X264_VERSION=20190419-2245-stable \
+            X265_VERSION=3.0          \
             XVID_VERSION=1.3.4        \
             FREETYPE_VERSION=2.5.5    \
             FRIBIDI_VERSION=0.19.7    \
@@ -72,6 +72,7 @@ RUN      buildDeps="autoconf \
                     python \
                     libssl-dev \
                     yasm \
+                    nasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
         apt-get install -yq --no-install-recommends ${buildDeps}

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -43,8 +43,8 @@ ENV         FFMPEG_VERSION=4.1.3      \
             AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
-ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9  opus-1.2.tar.gz"
+ARG         OGG_SHA256SUM="c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985  libogg-1.3.3.tar.gz"
+ARG         OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d  opus-1.3.1.tar.gz"
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"

--- a/docker-images/4.1/vaapi/Dockerfile
+++ b/docker-images/4.1/vaapi/Dockerfile
@@ -43,8 +43,8 @@ ENV         FFMPEG_VERSION=4.1.3      \
             AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
-ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9  opus-1.2.tar.gz"
+ARG         OGG_SHA256SUM="c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985  libogg-1.3.3.tar.gz"
+ARG         OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d  opus-1.3.1.tar.gz"
 ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce  libvorbis-1.3.5.tar.gz"
 ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b  libtheora-1.1.1.tar.gz"
 ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f  xvidcore-1.3.4.tar.gz"

--- a/docker-images/4.1/vaapi/Dockerfile
+++ b/docker-images/4.1/vaapi/Dockerfile
@@ -21,19 +21,19 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.1.3     \
-            FDKAAC_VERSION=0.1.5      \
+ENV         FFMPEG_VERSION=4.1.3      \
+            FDKAAC_VERSION=2.0.0      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
-            OGG_VERSION=1.3.2         \
+            OGG_VERSION=1.3.3         \
             OPENCOREAMR_VERSION=0.1.5 \
-            OPUS_VERSION=1.2          \
+            OPUS_VERSION=1.3.1        \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
             VPX_VERSION=1.8.0         \
-            X264_VERSION=20170226-2245-stable \
-            X265_VERSION=2.3          \
+            X264_VERSION=20190419-2245-stable \
+            X265_VERSION=3.0          \
             XVID_VERSION=1.3.4        \
             FREETYPE_VERSION=2.5.5    \
             FRIBIDI_VERSION=0.19.7    \
@@ -72,6 +72,7 @@ RUN      buildDeps="autoconf \
                     python \
                     libssl-dev \
                     yasm \
+                    nasm \
                     libva-dev \
                     zlib1g-dev" && \
         apt-get -yqq update && \


### PR DESCRIPTION
I updated some libraries for the ffmpeg 4.1 builds. I am currently building the alpine version locally on my machine. (my last attempt failed because I hadn't updated the checksums)

If you want I can edit the library versions for the other ffmpeg builds as well.