### PR TITLE
4.0.4 was released on 2019-03-28. It is the latest stable FFmpeg rele…

### DIFF
--- a/docker-images/4.0/alpine/Dockerfile
+++ b/docker-images/4.0/alpine/Dockerfile
@@ -18,7 +18,7 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.0.3     \
+ENV         FFMPEG_VERSION=4.0.4     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \

--- a/docker-images/4.0/centos/Dockerfile
+++ b/docker-images/4.0/centos/Dockerfile
@@ -20,7 +20,7 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.0.3     \
+ENV         FFMPEG_VERSION=4.0.4     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -13,7 +13,7 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.0.3     \
+ENV         FFMPEG_VERSION=4.0.4     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \

--- a/docker-images/4.0/ubuntu/Dockerfile
+++ b/docker-images/4.0/ubuntu/Dockerfile
@@ -21,7 +21,7 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.0.3     \
+ENV         FFMPEG_VERSION=4.0.4     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -21,7 +21,7 @@ ARG        LD_LIBRARY_PATH=/opt/ffmpeg/lib
 ARG        PREFIX=/opt/ffmpeg
 ARG        MAKEFLAGS="-j2"
 
-ENV         FFMPEG_VERSION=4.0.3     \
+ENV         FFMPEG_VERSION=4.0.4     \
             FDKAAC_VERSION=0.1.5      \
             LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \


### PR DESCRIPTION
…ase from the 4.0 release branch, which was cut from master on 2018-04-16.

It includes the following library versions:

libavutil      56. 14.100
libavcodec     58. 18.100
libavformat    58. 12.100
libavdevice    58.  3.100
libavfilter     7. 16.100
libswscale      5.  1.100
libswresample   3.  1.100
libpostproc    55.  1.100