### PR TITLE
fix nasm unavailable or outdated for libx265 > 2.6

### DIFF
--- a/docker-images/2.8/alpine/Dockerfile
+++ b/docker-images/2.8/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/2.8/scratch/Dockerfile
+++ b/docker-images/2.8/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/2.8/ubuntu/Dockerfile
+++ b/docker-images/2.8/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.0/alpine/Dockerfile
+++ b/docker-images/3.0/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/3.0/scratch/Dockerfile
+++ b/docker-images/3.0/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/3.0/ubuntu/Dockerfile
+++ b/docker-images/3.0/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.1/alpine/Dockerfile
+++ b/docker-images/3.1/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/3.1/scratch/Dockerfile
+++ b/docker-images/3.1/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/3.1/ubuntu/Dockerfile
+++ b/docker-images/3.1/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/3.2/ubuntu/Dockerfile
+++ b/docker-images/3.2/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/3.3/ubuntu/Dockerfile
+++ b/docker-images/3.3/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/3.4/ubuntu/Dockerfile
+++ b/docker-images/3.4/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/4.0/alpine/Dockerfile
+++ b/docker-images/4.0/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/4.0/ubuntu/Dockerfile
+++ b/docker-images/4.0/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/4.2/alpine/Dockerfile
+++ b/docker-images/4.2/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/4.2/scratch/Dockerfile
+++ b/docker-images/4.2/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/4.2/ubuntu/Dockerfile
+++ b/docker-images/4.2/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/docker-images/snapshot/alpine/Dockerfile
+++ b/docker-images/snapshot/alpine/Dockerfile
@@ -72,6 +72,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/docker-images/snapshot/scratch/Dockerfile
+++ b/docker-images/snapshot/scratch/Dockerfile
@@ -68,6 +68,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/docker-images/snapshot/ubuntu/Dockerfile
+++ b/docker-images/snapshot/ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 

--- a/templates/Dockerfile-template.alpine
+++ b/templates/Dockerfile-template.alpine
@@ -39,6 +39,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    expat-dev" && \
         apk  add --no-cache --update ${buildDeps}

--- a/templates/Dockerfile-template.scratch
+++ b/templates/Dockerfile-template.scratch
@@ -35,6 +35,7 @@ RUN     buildDeps="autoconf \
                    openssl-dev \
                    tar \
                    yasm \
+                   nasm \
                    zlib-dev \
                    git" && \
         apk  add --update ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0

--- a/templates/Dockerfile-template.ubuntu
+++ b/templates/Dockerfile-template.ubuntu
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:18.04 AS base
 
 WORKDIR     /tmp/workdir
 


### PR DESCRIPTION
Add nasm as buildDeps on alpine images
Use ubuntu 18.04  as base for ubuntu image

fix following issue: 
https://github.com/jrottenberg/ffmpeg/issues/166