### PR TITLE
CentOS cmake version - Use cmake3 and symlink it over to /usr/bin/cmake

### DIFF
--- a/templates/Dockerfile-template.centos
+++ b/templates/Dockerfile-template.centos
@@ -25,7 +25,7 @@ ENV         %%ENV%%
 RUN     buildDeps="autoconf \
                    automake \
                    bzip2 \
-                   cmake \
+                   cmake3 \
                    expat-devel \
                    gcc \
                    gcc-c++ \
@@ -42,7 +42,8 @@ RUN     buildDeps="autoconf \
                    zlib-devel" && \
         echo "${SRC}/lib" > /etc/ld.so.conf.d/libc.conf && \
         yum --enablerepo=extras install -y epel-release && \
-        yum install -y ${buildDeps}
+        yum --enablerepo=epel install -y ${buildDeps} && \
+        ln -s /usr/bin/cmake3 /usr/bin/cmake
 %%RUN%%
 RUN \
         ldd ${PREFIX}/bin/ffmpeg | grep opt/ffmpeg | cut -d ' ' -f 3 | xargs -i cp {} /usr/local/lib64/ && \


### PR DESCRIPTION
Another, much smaller change, option to fix #157 

If we just replace cmake with cmake3 and then create a symlink for the `cmake` command. Everything builds _fine_ with cmake v3 so for our purposes this is ok.

It's not the nicest solution, but it looks simpler than going through all of the templates and make the cmake command a variable so that in some cases we can call the command `cmake3` and others just use `cmake`