### PR TITLE
fix libxml2 ./autogen.sh in recent versions, not just ./configure

### DIFF
--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.2/centos/Dockerfile
+++ b/docker-images/3.2/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.2/nvidia/Dockerfile
+++ b/docker-images/3.2/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.2/ubuntu/Dockerfile
+++ b/docker-images/3.2/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/centos/Dockerfile
+++ b/docker-images/3.3/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/nvidia/Dockerfile
+++ b/docker-images/3.3/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/ubuntu/Dockerfile
+++ b/docker-images/3.3/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.3/vaapi/Dockerfile
+++ b/docker-images/3.3/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/centos/Dockerfile
+++ b/docker-images/3.4/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/nvidia/Dockerfile
+++ b/docker-images/3.4/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/ubuntu/Dockerfile
+++ b/docker-images/3.4/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/3.4/vaapi/Dockerfile
+++ b/docker-images/3.4/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/alpine/Dockerfile
+++ b/docker-images/4.0/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/centos/Dockerfile
+++ b/docker-images/4.0/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/nvidia/Dockerfile
+++ b/docker-images/4.0/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/ubuntu/Dockerfile
+++ b/docker-images/4.0/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/centos/Dockerfile
+++ b/docker-images/4.1/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/nvidia/Dockerfile
+++ b/docker-images/4.1/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.1/vaapi/Dockerfile
+++ b/docker-images/4.1/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/alpine/Dockerfile
+++ b/docker-images/4.2/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/centos/Dockerfile
+++ b/docker-images/4.2/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/nvidia/Dockerfile
+++ b/docker-images/4.2/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/scratch/Dockerfile
+++ b/docker-images/4.2/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/ubuntu/Dockerfile
+++ b/docker-images/4.2/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/4.2/vaapi/Dockerfile
+++ b/docker-images/4.2/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/alpine/Dockerfile
+++ b/docker-images/snapshot/alpine/Dockerfile
@@ -405,7 +405,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/centos/Dockerfile
+++ b/docker-images/snapshot/centos/Dockerfile
@@ -408,7 +408,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/nvidia/Dockerfile
+++ b/docker-images/snapshot/nvidia/Dockerfile
@@ -431,7 +431,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/scratch/Dockerfile
+++ b/docker-images/snapshot/scratch/Dockerfile
@@ -402,7 +402,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/ubuntu/Dockerfile
+++ b/docker-images/snapshot/ubuntu/Dockerfile
@@ -406,7 +406,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/docker-images/snapshot/vaapi/Dockerfile
+++ b/docker-images/snapshot/vaapi/Dockerfile
@@ -407,7 +407,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}

--- a/templates/Dockerfile-run
+++ b/templates/Dockerfile-run
@@ -317,7 +317,7 @@ RUN \
         curl -sLO https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${LIBXML2_VERSION}/libxml2-v${LIBXML2_VERSION}.tar.gz && \
         echo ${LIBXML2_SHA256SUM} | sha256sum --check && \
         tar -xz --strip-components=1 -f libxml2-v${LIBXML2_VERSION}.tar.gz && \
-        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./configure --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" ./autogen.sh --prefix="${PREFIX}" --with-ftp=no --with-http=no --with-python=no && \
         make && \
         make install && \
         rm -rf ${DIR}


### PR DESCRIPTION
Fixes the issue pointed out in #213 

Turns out newer versions of libxml2 are published not ready to just be built, they need to be autoconf'd first... 

I guess that's what I get for not actually checking the output of the builds after just bumping the version and assuming it would be fine 😞 