### PR TITLE
Enable fontconfig in ffmpeg

### DIFF
--- a/docker-images/3.2/alpine/Dockerfile
+++ b/docker-images/3.2/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.2/centos/Dockerfile
+++ b/docker-images/3.2/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.2/nvidia/Dockerfile
+++ b/docker-images/3.2/nvidia/Dockerfile
@@ -471,6 +471,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.2/scratch/Dockerfile
+++ b/docker-images/3.2/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.2/ubuntu/Dockerfile
+++ b/docker-images/3.2/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.2/vaapi/Dockerfile
+++ b/docker-images/3.2/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/alpine/Dockerfile
+++ b/docker-images/3.3/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/centos/Dockerfile
+++ b/docker-images/3.3/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/nvidia/Dockerfile
+++ b/docker-images/3.3/nvidia/Dockerfile
@@ -471,6 +471,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/scratch/Dockerfile
+++ b/docker-images/3.3/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/ubuntu/Dockerfile
+++ b/docker-images/3.3/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.3/vaapi/Dockerfile
+++ b/docker-images/3.3/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/alpine/Dockerfile
+++ b/docker-images/3.4/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/centos/Dockerfile
+++ b/docker-images/3.4/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/nvidia/Dockerfile
+++ b/docker-images/3.4/nvidia/Dockerfile
@@ -471,6 +471,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/scratch/Dockerfile
+++ b/docker-images/3.4/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/ubuntu/Dockerfile
+++ b/docker-images/3.4/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/3.4/vaapi/Dockerfile
+++ b/docker-images/3.4/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/alpine/Dockerfile
+++ b/docker-images/4.0/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/centos/Dockerfile
+++ b/docker-images/4.0/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/nvidia/Dockerfile
+++ b/docker-images/4.0/nvidia/Dockerfile
@@ -474,6 +474,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/scratch/Dockerfile
+++ b/docker-images/4.0/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/ubuntu/Dockerfile
+++ b/docker-images/4.0/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.0/vaapi/Dockerfile
+++ b/docker-images/4.0/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/alpine/Dockerfile
+++ b/docker-images/4.1/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/centos/Dockerfile
+++ b/docker-images/4.1/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/nvidia/Dockerfile
+++ b/docker-images/4.1/nvidia/Dockerfile
@@ -474,6 +474,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/scratch/Dockerfile
+++ b/docker-images/4.1/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/ubuntu/Dockerfile
+++ b/docker-images/4.1/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.1/vaapi/Dockerfile
+++ b/docker-images/4.1/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/alpine/Dockerfile
+++ b/docker-images/4.2/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/centos/Dockerfile
+++ b/docker-images/4.2/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/nvidia/Dockerfile
+++ b/docker-images/4.2/nvidia/Dockerfile
@@ -474,6 +474,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/scratch/Dockerfile
+++ b/docker-images/4.2/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/ubuntu/Dockerfile
+++ b/docker-images/4.2/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/4.2/vaapi/Dockerfile
+++ b/docker-images/4.2/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/alpine/Dockerfile
+++ b/docker-images/snapshot/alpine/Dockerfile
@@ -444,6 +444,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/centos/Dockerfile
+++ b/docker-images/snapshot/centos/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/nvidia/Dockerfile
+++ b/docker-images/snapshot/nvidia/Dockerfile
@@ -474,6 +474,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/scratch/Dockerfile
+++ b/docker-images/snapshot/scratch/Dockerfile
@@ -441,6 +441,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/ubuntu/Dockerfile
+++ b/docker-images/snapshot/ubuntu/Dockerfile
@@ -445,6 +445,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/docker-images/snapshot/vaapi/Dockerfile
+++ b/docker-images/snapshot/vaapi/Dockerfile
@@ -447,6 +447,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \

--- a/templates/Dockerfile-run
+++ b/templates/Dockerfile-run
@@ -356,6 +356,7 @@ RUN \
         --enable-libopencore-amrwb \
         --enable-gpl \
         --enable-libass \
+        --enable-fontconfig \
         --enable-libfreetype \
         --enable-libvidstab \
         --enable-libmp3lame \


### PR DESCRIPTION
Since we already compile fontconfig I don't see why we shouldn't enable it in ffmpeg. Makes it easier to use fonts.

Fixes https://github.com/jrottenberg/ffmpeg/issues/73 since font "auto-loading" will work after this.