### PR TITLE
Use the latest nvidia/cuda runtime (10.2)

### DIFF
--- a/docker-images/3.2/nvidia1604/Dockerfile
+++ b/docker-images/3.2/nvidia1604/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu16.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu16.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu16.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu16.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/3.3/nvidia1804/Dockerfile
+++ b/docker-images/3.3/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/3.4/nvidia1804/Dockerfile
+++ b/docker-images/3.4/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/4.0/nvidia1804/Dockerfile
+++ b/docker-images/4.0/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/4.1/nvidia1804/Dockerfile
+++ b/docker-images/4.1/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/4.2/nvidia1804/Dockerfile
+++ b/docker-images/4.2/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/docker-images/snapshot/nvidia1804/Dockerfile
+++ b/docker-images/snapshot/nvidia1804/Dockerfile
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/templates/Dockerfile-template.nvidia1604
+++ b/templates/Dockerfile-template.nvidia1604
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu16.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu16.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu16.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu16.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \

--- a/templates/Dockerfile-template.nvidia1804
+++ b/templates/Dockerfile-template.nvidia1804
@@ -6,9 +6,9 @@
 #
 #
 
-FROM    nvidia/cuda:9.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +16,9 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:9.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
 
-ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \


### PR DESCRIPTION
This also changes the build to use the nvidia/cuda images instead of nvidia/cudagl. The driver capabilities have also been changed, compat32 doesn't seem to make any sense.