### PR TITLE
add sftp support

### DIFF
--- a/docker-images/3.2/alpine38/Dockerfile
+++ b/docker-images/3.2/alpine38/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.8 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.2/centos7/Dockerfile
+++ b/docker-images/3.2/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.2/nvidia1604/Dockerfile
+++ b/docker-images/3.2/nvidia1604/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.2/scratch38/Dockerfile
+++ b/docker-images/3.2/scratch38/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.2/ubuntu1604/Dockerfile
+++ b/docker-images/3.2/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.2/vaapi1604/Dockerfile
+++ b/docker-images/3.2/vaapi1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/alpine311/Dockerfile
+++ b/docker-images/3.3/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/centos7/Dockerfile
+++ b/docker-images/3.3/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/centos8/Dockerfile
+++ b/docker-images/3.3/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/nvidia1804/Dockerfile
+++ b/docker-images/3.3/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/scratch311/Dockerfile
+++ b/docker-images/3.3/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/ubuntu1604/Dockerfile
+++ b/docker-images/3.3/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/ubuntu1804/Dockerfile
+++ b/docker-images/3.3/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.3/vaapi1804/Dockerfile
+++ b/docker-images/3.3/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/alpine311/Dockerfile
+++ b/docker-images/3.4/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/centos7/Dockerfile
+++ b/docker-images/3.4/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/centos8/Dockerfile
+++ b/docker-images/3.4/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/nvidia1804/Dockerfile
+++ b/docker-images/3.4/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/scratch311/Dockerfile
+++ b/docker-images/3.4/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/ubuntu1604/Dockerfile
+++ b/docker-images/3.4/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/ubuntu1804/Dockerfile
+++ b/docker-images/3.4/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/3.4/vaapi1804/Dockerfile
+++ b/docker-images/3.4/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/alpine311/Dockerfile
+++ b/docker-images/4.0/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/centos7/Dockerfile
+++ b/docker-images/4.0/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/centos8/Dockerfile
+++ b/docker-images/4.0/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/nvidia1804/Dockerfile
+++ b/docker-images/4.0/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/scratch311/Dockerfile
+++ b/docker-images/4.0/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/ubuntu1604/Dockerfile
+++ b/docker-images/4.0/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/ubuntu1804/Dockerfile
+++ b/docker-images/4.0/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.0/vaapi1804/Dockerfile
+++ b/docker-images/4.0/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/alpine311/Dockerfile
+++ b/docker-images/4.1/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/centos7/Dockerfile
+++ b/docker-images/4.1/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/centos8/Dockerfile
+++ b/docker-images/4.1/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/nvidia1804/Dockerfile
+++ b/docker-images/4.1/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/scratch311/Dockerfile
+++ b/docker-images/4.1/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/ubuntu1604/Dockerfile
+++ b/docker-images/4.1/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/ubuntu1804/Dockerfile
+++ b/docker-images/4.1/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.1/vaapi1804/Dockerfile
+++ b/docker-images/4.1/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/alpine311/Dockerfile
+++ b/docker-images/4.2/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/centos7/Dockerfile
+++ b/docker-images/4.2/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/centos8/Dockerfile
+++ b/docker-images/4.2/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/nvidia1804/Dockerfile
+++ b/docker-images/4.2/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/scratch311/Dockerfile
+++ b/docker-images/4.2/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/ubuntu1604/Dockerfile
+++ b/docker-images/4.2/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/ubuntu1804/Dockerfile
+++ b/docker-images/4.2/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.2/vaapi1804/Dockerfile
+++ b/docker-images/4.2/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/alpine311/Dockerfile
+++ b/docker-images/4.3/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/alpine38/Dockerfile
+++ b/docker-images/4.3/alpine38/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.8 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/centos7/Dockerfile
+++ b/docker-images/4.3/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/centos8/Dockerfile
+++ b/docker-images/4.3/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/nvidia1604/Dockerfile
+++ b/docker-images/4.3/nvidia1604/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/nvidia1804/Dockerfile
+++ b/docker-images/4.3/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/scratch311/Dockerfile
+++ b/docker-images/4.3/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/scratch38/Dockerfile
+++ b/docker-images/4.3/scratch38/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/ubuntu1604/Dockerfile
+++ b/docker-images/4.3/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/ubuntu1804/Dockerfile
+++ b/docker-images/4.3/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/vaapi1604/Dockerfile
+++ b/docker-images/4.3/vaapi1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/4.3/vaapi1804/Dockerfile
+++ b/docker-images/4.3/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/alpine311/Dockerfile
+++ b/docker-images/snapshot/alpine311/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -86,6 +86,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -516,6 +517,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/centos7/Dockerfile
+++ b/docker-images/snapshot/centos7/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -553,6 +554,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/centos8/Dockerfile
+++ b/docker-images/snapshot/centos8/Dockerfile
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -87,6 +87,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \
@@ -519,6 +520,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/nvidia1804/Dockerfile
+++ b/docker-images/snapshot/nvidia1804/Dockerfile
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -104,6 +104,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -542,6 +543,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/scratch311/Dockerfile
+++ b/docker-images/snapshot/scratch311/Dockerfile
@@ -82,6 +82,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/ubuntu1604/Dockerfile
+++ b/docker-images/snapshot/ubuntu1604/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -90,6 +90,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/ubuntu1804/Dockerfile
+++ b/docker-images/snapshot/ubuntu1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \
@@ -517,6 +518,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/docker-images/snapshot/vaapi1804/Dockerfile
+++ b/docker-images/snapshot/vaapi1804/Dockerfile
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -89,6 +89,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \
@@ -518,6 +519,7 @@ RUN \
         --enable-libxvid \
         --enable-libx264 \
         --enable-nonfree \
+        --enable-libssh \
         --enable-openssl \
         --enable-libfdk_aac \
         --enable-postproc \

--- a/templates/Dockerfile-template.alpine311
+++ b/templates/Dockerfile-template.alpine311
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.11 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.1 libssl1.1 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -31,6 +31,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.alpine38
+++ b/templates/Dockerfile-template.alpine38
@@ -6,7 +6,7 @@
 
 FROM        alpine:3.8 AS base
 
-RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git
+RUN         apk add --no-cache --update libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0 libgomp expat git libssh
 
 
 FROM        base AS build
@@ -31,6 +31,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.centos7
+++ b/templates/Dockerfile-template.centos7
@@ -7,7 +7,7 @@
 #
 FROM    centos:7 AS base
 
-RUN     yum -y install libgomp && \
+RUN     yum -y install libgomp libssh && \
         yum clean all;
 
 
@@ -32,6 +32,7 @@ RUN     buildDeps="autoconf \
                    make \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.centos8
+++ b/templates/Dockerfile-template.centos8
@@ -7,7 +7,7 @@
 #
 FROM    centos:8 AS base
 
-RUN     dnf -y install libgomp && \
+RUN     dnf -y install libgomp libssh && \
         dnf clean all;
 
 
@@ -32,6 +32,7 @@ RUN     buildDeps="autoconf \
                    nasm \
                    perl \
                    python3 \
+                   libssh-devel \
                    openssl-devel \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.nvidia
+++ b/templates/Dockerfile-template.nvidia
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compat32,compute,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -53,6 +53,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \

--- a/templates/Dockerfile-template.nvidia1604
+++ b/templates/Dockerfile-template.nvidia1604
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -49,6 +49,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \

--- a/templates/Dockerfile-template.nvidia1804
+++ b/templates/Dockerfile-template.nvidia1804
@@ -22,7 +22,7 @@ ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -49,6 +49,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \

--- a/templates/Dockerfile-template.scratch311
+++ b/templates/Dockerfile-template.scratch311
@@ -27,6 +27,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.scratch38
+++ b/templates/Dockerfile-template.scratch38
@@ -27,6 +27,7 @@ RUN     buildDeps="autoconf \
                    libtool \
                    make \
                    python \
+                   libssh-dev \
                    openssl-dev \
                    tar \
                    yasm \

--- a/templates/Dockerfile-template.ubuntu1604
+++ b/templates/Dockerfile-template.ubuntu1604
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -35,6 +35,7 @@ RUN      buildDeps="autoconf \
                     pkg-config \
                     python \
                     libssl-dev \
+                    libssh-dev \
                     yasm \
                     zlib1g-dev" && \
         apt-get -yqq update && \

--- a/templates/Dockerfile-template.ubuntu1804
+++ b/templates/Dockerfile-template.ubuntu1804
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -34,6 +34,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     zlib1g-dev" && \

--- a/templates/Dockerfile-template.vaapi1604
+++ b/templates/Dockerfile-template.vaapi1604
@@ -10,7 +10,7 @@ FROM        ubuntu:16.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -34,6 +34,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \

--- a/templates/Dockerfile-template.vaapi1804
+++ b/templates/Dockerfile-template.vaapi1804
@@ -10,7 +10,7 @@ FROM        ubuntu:18.04 AS base
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
-        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libssh-4 && \
         apt-get autoremove -y && \
         apt-get clean -y
 
@@ -34,6 +34,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
+                    libssh-dev \
                     libssl-dev \
                     yasm \
                     libva-dev \

--- a/update.py
+++ b/update.py
@@ -179,6 +179,7 @@ for version in keep_version:
             "--enable-libxvid",
             "--enable-libx264",
             "--enable-nonfree",
+            "--enable-libssh",
             "--enable-openssl",
             "--enable-libfdk_aac",
             "--enable-postproc",


### PR DESCRIPTION
Related to #265 

Currently centos 7 is broken
```
Step 58/64 : RUN         DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} &&         ./configure         --disable-debug         --disable-doc         --disable-ffplay         --enable-shared         --enable-avresample         --enable-libopencore-amrnb         --enable-libopencore-amrwb         --enable-gpl         --enable-libass         --enable-fontconfig         --enable-libfreetype         --enable-libvidstab         --enable-libmp3lame         --enable-libopus         --enable-libtheora         --enable-libvorbis         --enable-libvpx         --enable-libwebp         --enable-libxcb         --enable-libx265         --enable-libxvid         --enable-libx264         --enable-nonfree         --enable-libssh         --enable-openssl         --enable-libfdk_aac         --enable-postproc         --enable-small         --enable-version3         --enable-libbluray         --enable-libzmq         --extra-libs=-ldl         --prefix="${PREFIX}"         --enable-libopenjpeg         --enable-libkvazaar         --enable-libaom         --extra-libs=-lpthread         --enable-libsrt         --enable-libaribb24         --extra-cflags="-I${PREFIX}/include"         --extra-ldflags="-L${PREFIX}/lib" &&         make &&         make install &&         make tools/zmqsend && cp tools/zmqsend ${PREFIX}/bin/ &&         make distclean &&         hash -r &&         cd tools &&         make qt-faststart && cp qt-faststart ${PREFIX}/bin/
 ---> Running in c261a1eaee03
ERROR: aom >= 1.0.0 not found using pkg-config
```
don't know how my changes can affect aom.

I add libssh to base image in addition to libssh-dev to build image but it may not be necessary to.