### PR TITLE
Fix vaapi 2004 builds using 1604 instead

### DIFF
--- a/docker-images/3.2/vaapi2004/Dockerfile
+++ b/docker-images/3.2/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -565,7 +565,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.3/vaapi2004/Dockerfile
+++ b/docker-images/3.3/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -565,7 +565,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/3.4/vaapi2004/Dockerfile
+++ b/docker-images/3.4/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -565,7 +565,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.0/vaapi2004/Dockerfile
+++ b/docker-images/4.0/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -568,7 +568,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.1/vaapi2004/Dockerfile
+++ b/docker-images/4.1/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -568,7 +568,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.2/vaapi2004/Dockerfile
+++ b/docker-images/4.2/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -569,7 +569,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/4.3/vaapi2004/Dockerfile
+++ b/docker-images/4.3/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -569,7 +569,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/docker-images/snapshot/vaapi2004/Dockerfile
+++ b/docker-images/snapshot/vaapi2004/Dockerfile
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -569,7 +569,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly

--- a/templates/Dockerfile-template.vaapi2004
+++ b/templates/Dockerfile-template.vaapi2004
@@ -5,7 +5,7 @@
 # https://hub.docker.com/r/jrottenberg/ffmpeg/
 #
 #
-FROM        ubuntu:16.04 AS base
+FROM        ubuntu:20.04 AS base
 
 WORKDIR     /tmp/workdir
 
@@ -66,7 +66,7 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm1 libva1 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
 	rm -rf /var/lib/apt/lists/*
 
 # Let's make sure the app built correctly


### PR DESCRIPTION
Should fix the obvious parts of #271 

Not sure if the line `ARG DEBIAN_FRONTEND=noninteractive` is also needed (it is added from ubuntu1804 > ubuntu2004 builds) because unfortunately I currently have no test environment at hand.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>