### PR TITLE
bring nvidia2004 up2date with nvidia-headers and cuda containers

### DIFF
--- a/docker-images/3.3/nvidia2004/Dockerfile
+++ b/docker-images/3.3/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=3.3.9 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/3.4/nvidia2004/Dockerfile
+++ b/docker-images/3.4/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=3.4.8 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/4.0/nvidia2004/Dockerfile
+++ b/docker-images/4.0/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=4.0.6 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/4.1/alpine312/Dockerfile
+++ b/docker-images/4.1/alpine312/Dockerfile
@@ -13,7 +13,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/centos7/Dockerfile
+++ b/docker-images/4.1/centos7/Dockerfile
@@ -15,7 +15,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/centos8/Dockerfile
+++ b/docker-images/4.1/centos8/Dockerfile
@@ -15,7 +15,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/nvidia2004/Dockerfile
+++ b/docker-images/4.1/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,9 +31,9 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/scratch312/Dockerfile
+++ b/docker-images/4.1/scratch312/Dockerfile
@@ -8,7 +8,7 @@ FROM        alpine:3.12 AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/ubuntu1804/Dockerfile
+++ b/docker-images/4.1/ubuntu1804/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/ubuntu2004/Dockerfile
+++ b/docker-images/4.1/ubuntu2004/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.1/vaapi2004/Dockerfile
+++ b/docker-images/4.1/vaapi2004/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=4.1.6 \
+ENV         FFMPEG_VERSION=4.1.7 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.2/nvidia2004/Dockerfile
+++ b/docker-images/4.2/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=4.2.4 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/4.3/nvidia2004/Dockerfile
+++ b/docker-images/4.3/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=4.3.2 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/4.4/nvidia2004/Dockerfile
+++ b/docker-images/4.4/nvidia2004/Dockerfile
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         FFMPEG_VERSION=4.4 \
             AOM_VERSION=v1.0.0 \

--- a/docker-images/azure-jobs.yml
+++ b/docker-images/azure-jobs.yml
@@ -277,73 +277,73 @@ jobs:
         ISPARENT:  True
 
 
-      ubuntu1804_4.1.6:
+      ubuntu1804_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  ubuntu1804
         PARENT: ubuntu
         ISPARENT:  False
 
 
-      ubuntu2004_4.1.6:
+      ubuntu2004_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  ubuntu2004
         PARENT: ubuntu
         ISPARENT:  True
 
 
-      alpine312_4.1.6:
+      alpine312_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  alpine312
         PARENT: alpine
         ISPARENT:  True
 
 
-      centos7_4.1.6:
+      centos7_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  centos7
         PARENT: centos
         ISPARENT:  False
 
 
-      centos8_4.1.6:
+      centos8_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  centos8
         PARENT: centos
         ISPARENT:  True
 
 
-      scratch312_4.1.6:
+      scratch312_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  scratch312
         PARENT: scratch
         ISPARENT:  True
 
 
-      vaapi2004_4.1.6:
+      vaapi2004_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  vaapi2004
         PARENT: vaapi
         ISPARENT:  True
 
 
-      nvidia2004_4.1.6:
+      nvidia2004_4.1.7:
         MAJOR_VERSION: 4
         VERSION:  4.1
-        LONG_VERSION: 4.1.6
+        LONG_VERSION: 4.1.7
         VARIANT:  nvidia2004
         PARENT: nvidia
         ISPARENT:  True

--- a/docker-images/gitlab-ci.yml
+++ b/docker-images/gitlab-ci.yml
@@ -329,90 +329,90 @@
     PARENT: "nvidia"
     ISPARENT: "True"
 
-4.1.6-ubuntu1804:
+4.1.7-ubuntu1804:
   extends: .docker
   stage: ubuntu1804
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: ubuntu1804
     PARENT: "ubuntu"
     ISPARENT: "False"
 
-4.1.6-ubuntu2004:
+4.1.7-ubuntu2004:
   extends: .docker
   stage: ubuntu2004
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: ubuntu2004
     PARENT: "ubuntu"
     ISPARENT: "True"
 
-4.1.6-alpine312:
+4.1.7-alpine312:
   extends: .docker
   stage: alpine312
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: alpine312
     PARENT: "alpine"
     ISPARENT: "True"
 
-4.1.6-centos7:
+4.1.7-centos7:
   extends: .docker
   stage: centos7
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: centos7
     PARENT: "centos"
     ISPARENT: "False"
 
-4.1.6-centos8:
+4.1.7-centos8:
   extends: .docker
   stage: centos8
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: centos8
     PARENT: "centos"
     ISPARENT: "True"
 
-4.1.6-scratch312:
+4.1.7-scratch312:
   extends: .docker
   stage: scratch312
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: scratch312
     PARENT: "scratch"
     ISPARENT: "True"
 
-4.1.6-vaapi2004:
+4.1.7-vaapi2004:
   extends: .docker
   stage: vaapi2004
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: vaapi2004
     PARENT: "vaapi"
     ISPARENT: "True"
 
-4.1.6-nvidia2004:
+4.1.7-nvidia2004:
   extends: .docker
   stage: nvidia2004
   variables:
     MAJOR_VERSION: 4
     VERSION: "4.1"
-    LONG_VERSION: "4.1.6"
+    LONG_VERSION: "4.1.7"
     VARIANT: nvidia2004
     PARENT: "nvidia"
     ISPARENT: "True"

--- a/templates/Dockerfile-template.nvidia2004
+++ b/templates/Dockerfile-template.nvidia2004
@@ -6,9 +6,10 @@
 #
 #
 
-FROM    nvidia/cuda:10.2-devel-ubuntu18.04 AS devel-base
+FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -16,9 +17,10 @@ RUN     apt-get -yqq update && \
         apt-get autoremove -y && \
         apt-get clean -y
 
-FROM        nvidia/cuda:10.2-runtime-ubuntu18.04 AS runtime-base
+FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -29,7 +31,7 @@ RUN     apt-get -yqq update && \
 
 FROM  devel-base as build
 
-ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
 ENV         %%ENV%%
 


### PR DESCRIPTION
Will fix #314 

verified on:
host machine: fedora34
docker-ce-20.10.8-3.fc34.x86_64
nvidia-docker2-2.5.0-3.noarch
nvidia-driver-470.63.01-2.fc34.x86_64
cuda-11.4.0-1.fc34.x86_64
VGA compatible controller: NVIDIA Corporation GP106GL [Quadro P2000] (rev a1)


```
INPUT="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
OUTPUT="output.mkv"
docker build . -t nvidia-ffmpeg-2004
docker run --privileged --gpus all -v $(pwd):$(pwd) -w $(pwd) nvidia-ffmpeg-2004 -hwaccel cuvid -c:v h264_cuvid -i ${INPUT} -vf scale_npp=1280:-1 -c:v h264_nvenc -b:v 2048k  -y ${OUTPUT}
```