### PR TITLE
enable cuda llvm on 4.2+

### DIFF
--- a/docker-images/3.3/nvidia2004/Dockerfile
+++ b/docker-images/3.3/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \

--- a/docker-images/3.4/alpine312/Dockerfile
+++ b/docker-images/3.4/alpine312/Dockerfile
@@ -13,7 +13,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/centos7/Dockerfile
+++ b/docker-images/3.4/centos7/Dockerfile
@@ -15,7 +15,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/centos8/Dockerfile
+++ b/docker-images/3.4/centos8/Dockerfile
@@ -15,7 +15,7 @@ FROM        base AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/nvidia2004/Dockerfile
+++ b/docker-images/3.4/nvidia2004/Dockerfile
@@ -33,7 +33,7 @@ FROM  devel-base as build
 
 ENV        NVIDIA_HEADERS_VERSION=11.1.5.0
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/nvidia2004/Dockerfile
+++ b/docker-images/3.4/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \

--- a/docker-images/3.4/scratch312/Dockerfile
+++ b/docker-images/3.4/scratch312/Dockerfile
@@ -8,7 +8,7 @@ FROM        alpine:3.12 AS build
 
 WORKDIR     /tmp/workdir
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/ubuntu1804/Dockerfile
+++ b/docker-images/3.4/ubuntu1804/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/ubuntu2004/Dockerfile
+++ b/docker-images/3.4/ubuntu2004/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/3.4/vaapi2004/Dockerfile
+++ b/docker-images/3.4/vaapi2004/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=3.4.8 \
+ENV         FFMPEG_VERSION=3.4.9 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/docker-images/4.0/nvidia2004/Dockerfile
+++ b/docker-images/4.0/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \

--- a/docker-images/4.1/nvidia2004/Dockerfile
+++ b/docker-images/4.1/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \

--- a/docker-images/4.2/nvidia2004/Dockerfile
+++ b/docker-images/4.2/nvidia2004/Dockerfile
@@ -587,6 +587,7 @@ RUN \
         --enable-cuvid \
         --enable-libnpp \
         --enable-cuda-llvm \
+        --enable-ffnvcodec \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/4.2/nvidia2004/Dockerfile
+++ b/docker-images/4.2/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \
@@ -585,6 +586,7 @@ RUN \
         --enable-cuda \
         --enable-cuvid \
         --enable-libnpp \
+        --enable-cuda-llvm \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/4.3/nvidia2004/Dockerfile
+++ b/docker-images/4.3/nvidia2004/Dockerfile
@@ -587,6 +587,7 @@ RUN \
         --enable-cuvid \
         --enable-libnpp \
         --enable-cuda-llvm \
+        --enable-ffnvcodec \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/4.3/nvidia2004/Dockerfile
+++ b/docker-images/4.3/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \
@@ -585,6 +586,7 @@ RUN \
         --enable-cuda \
         --enable-cuvid \
         --enable-libnpp \
+        --enable-cuda-llvm \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/4.4/nvidia2004/Dockerfile
+++ b/docker-images/4.4/nvidia2004/Dockerfile
@@ -587,6 +587,7 @@ RUN \
         --enable-cuvid \
         --enable-libnpp \
         --enable-cuda-llvm \
+        --enable-ffnvcodec \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/4.4/nvidia2004/Dockerfile
+++ b/docker-images/4.4/nvidia2004/Dockerfile
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -94,6 +94,7 @@ ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \
@@ -585,6 +586,7 @@ RUN \
         --enable-cuda \
         --enable-cuvid \
         --enable-libnpp \
+        --enable-cuda-llvm \
         --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
         --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
         make && \

--- a/docker-images/azure-jobs.yml
+++ b/docker-images/azure-jobs.yml
@@ -421,73 +421,73 @@ jobs:
         ISPARENT:  True
 
 
-      ubuntu1804_3.4.8:
+      ubuntu1804_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  ubuntu1804
         PARENT: ubuntu
         ISPARENT:  False
 
 
-      ubuntu2004_3.4.8:
+      ubuntu2004_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  ubuntu2004
         PARENT: ubuntu
         ISPARENT:  True
 
 
-      alpine312_3.4.8:
+      alpine312_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  alpine312
         PARENT: alpine
         ISPARENT:  True
 
 
-      centos7_3.4.8:
+      centos7_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  centos7
         PARENT: centos
         ISPARENT:  False
 
 
-      centos8_3.4.8:
+      centos8_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  centos8
         PARENT: centos
         ISPARENT:  True
 
 
-      scratch312_3.4.8:
+      scratch312_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  scratch312
         PARENT: scratch
         ISPARENT:  True
 
 
-      vaapi2004_3.4.8:
+      vaapi2004_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  vaapi2004
         PARENT: vaapi
         ISPARENT:  True
 
 
-      nvidia2004_3.4.8:
+      nvidia2004_3.4.9:
         MAJOR_VERSION: 3
         VERSION:  3.4
-        LONG_VERSION: 3.4.8
+        LONG_VERSION: 3.4.9
         VARIANT:  nvidia2004
         PARENT: nvidia
         ISPARENT:  True

--- a/docker-images/gitlab-ci.yml
+++ b/docker-images/gitlab-ci.yml
@@ -505,90 +505,90 @@
     PARENT: "nvidia"
     ISPARENT: "True"
 
-3.4.8-ubuntu1804:
+3.4.9-ubuntu1804:
   extends: .docker
   stage: ubuntu1804
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: ubuntu1804
     PARENT: "ubuntu"
     ISPARENT: "False"
 
-3.4.8-ubuntu2004:
+3.4.9-ubuntu2004:
   extends: .docker
   stage: ubuntu2004
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: ubuntu2004
     PARENT: "ubuntu"
     ISPARENT: "True"
 
-3.4.8-alpine312:
+3.4.9-alpine312:
   extends: .docker
   stage: alpine312
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: alpine312
     PARENT: "alpine"
     ISPARENT: "True"
 
-3.4.8-centos7:
+3.4.9-centos7:
   extends: .docker
   stage: centos7
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: centos7
     PARENT: "centos"
     ISPARENT: "False"
 
-3.4.8-centos8:
+3.4.9-centos8:
   extends: .docker
   stage: centos8
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: centos8
     PARENT: "centos"
     ISPARENT: "True"
 
-3.4.8-scratch312:
+3.4.9-scratch312:
   extends: .docker
   stage: scratch312
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: scratch312
     PARENT: "scratch"
     ISPARENT: "True"
 
-3.4.8-vaapi2004:
+3.4.9-vaapi2004:
   extends: .docker
   stage: vaapi2004
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: vaapi2004
     PARENT: "vaapi"
     ISPARENT: "True"
 
-3.4.8-nvidia2004:
+3.4.9-nvidia2004:
   extends: .docker
   stage: nvidia2004
   variables:
     MAJOR_VERSION: 3
     VERSION: "3.4"
-    LONG_VERSION: "3.4.8"
+    LONG_VERSION: "3.4.9"
     VARIANT: nvidia2004
     PARENT: "nvidia"
     ISPARENT: "True"

--- a/templates/Dockerfile-template.nvidia2004
+++ b/templates/Dockerfile-template.nvidia2004
@@ -9,7 +9,7 @@
 FROM    nvidia/cuda:11.4.1-devel-ubuntu20.04 AS devel-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -20,7 +20,7 @@ RUN     apt-get -yqq update && \
 FROM        nvidia/cuda:11.4.1-runtime-ubuntu20.04 AS runtime-base
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
-ENV	    DEBIAN_FRONTEND=nonintercative
+ENV	    DEBIAN_FRONTEND=noninteractive
 WORKDIR     /tmp/workdir
 
 RUN     apt-get -yqq update && \
@@ -37,6 +37,7 @@ ENV         %%ENV%%
 
 RUN      buildDeps="autoconf \
                     automake \
+                    clang \
                     cmake \
                     curl \
                     bzip2 \

--- a/update.py
+++ b/update.py
@@ -230,6 +230,8 @@ for version in keep_version:
                 FFMPEG_CONFIG_FLAGS.append("--enable-cuda")
                 FFMPEG_CONFIG_FLAGS.append("--enable-cuvid")
                 FFMPEG_CONFIG_FLAGS.append("--enable-libnpp")
+            if version == "snapshot" or float(version[0:3]) >= 4.2:
+                FFMPEG_CONFIG_FLAGS.append("--enable-cuda-llvm")
         cflags = '--extra-cflags="{0}"'.format(" ".join(CFLAGS))
         ldflags = '--extra-ldflags="{0}"'.format(" ".join(LDFLAGS))
         FFMPEG_CONFIG_FLAGS.append(cflags)

--- a/update.py
+++ b/update.py
@@ -232,6 +232,7 @@ for version in keep_version:
                 FFMPEG_CONFIG_FLAGS.append("--enable-libnpp")
             if version == "snapshot" or float(version[0:3]) >= 4.2:
                 FFMPEG_CONFIG_FLAGS.append("--enable-cuda-llvm")
+                FFMPEG_CONFIG_FLAGS.append("--enable-ffnvcodec")
         cflags = '--extra-cflags="{0}"'.format(" ".join(CFLAGS))
         ldflags = '--extra-ldflags="{0}"'.format(" ".join(LDFLAGS))
         FFMPEG_CONFIG_FLAGS.append(cflags)


### PR DESCRIPTION
This enables a few filters that I use, like `yadif_cuda` and `scale_cuda`, and may also remove the need for `--enable-cuda-sdk` from #234.

For #196 - this doesn't appear to be available with ffmpeg 4.1, but perhaps that was the latest version when the issue was created, and enabling the filter in newer versions will suffice.