### PR TITLE
fix ffmpeg filter drawtext on the containers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ In the bash shell, run the following commands
          but they are all there
    $ for i in ogg amr vorbis theora mp3lame opus vpx xvid fdk x264 x265;do echo $i; find /usr/local/ -name *$i*;done
    $ ffmpeg -buildconf
-   $ ffmpeg -filters 
+   $ ffmpeg -filters
 
 3: Convert an avi file to an mp4 file.
    `docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest -i drop_video_1.avi outfile/dv_converted.mp4`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,38 +55,38 @@ If you are not running the amd64 platform, you may need to pass in the --platfor
 - 7.1-ubuntu2404
 
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-ubuntu2404-desktop-build docker-images/7.1/ubuntu2404
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-ubuntu2404-desktop-build docker-images/7.1/ubuntu2404
 $ docker run -it --rm --entrypoint='bash' --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest
 ```
 
 - 7.1-ubuntu2404-edge
 
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-ubuntu2404-edge-desktop-build docker-images/7.1/ubuntu2404-edge
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-ubuntu2404-edge-desktop-build docker-images/7.1/ubuntu2404-edge
 $ docker run -it --rm --entrypoint='bash' --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-edge-desktop-build:latest
 ```
 
 - 7.1-nvidia2404
 
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-nvidia2404-desktop-build docker-images/7.1/nvidia2404
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-nvidia2404-desktop-build docker-images/7.1/nvidia2404
 $ docker run -it --rm --entrypoint='bash' --platform="linux/amd64" ffmpeg-7.1-nvidia2404-desktop-build:latest
 ```
 
 - vaapi2404
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-vaapi2404-desktop-build docker-images/7.1/vaapi2404
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-vaapi2404-desktop-build docker-images/7.1/vaapi2404
 $ docker run -it --rm --entrypoint='bash' --platform="linux/amd64" ffmpeg-7.1-vaapi2404-desktop-build:latest
 ```
 
 - alpine320
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-alpine320-desktop-build docker-images/7.1/alpine320
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-alpine320-desktop-build docker-images/7.1/alpine320
 $ docker run -it --rm --entrypoint='sh' --platform="linux/amd64" ffmpeg-7.1-alpine320-desktop-build:latest
 ```
 
 ```sh
-$ ./update.py; time docker build --platform linux/amd64 -t ffmpeg-7.1-scratch320-desktop-build docker-images/7.1/scratch320
+$ ./update.py; docker build --platform linux/amd64 -t ffmpeg-7.1-scratch320-desktop-build docker-images/7.1/scratch320
 $ docker run -it --rm --entrypoint='sh' --platform="linux/amd64" ffmpeg-7.1-scratch320-desktop-build:latest
 ```
 
@@ -117,8 +117,9 @@ In the bash shell, run the following commands
 4: Convert a asf file to an mp4
    `docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest -i MU_2_Discharge_Bottle___Inlet_to_Discharge.asf outfile/mpu2_discharge_bottle_converted.mp4`
 
+5: using a drawtext filter
+   `docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" jrottenberg/ffmpeg:7.1-ubuntu2404 -i sample-5s_1.mp4 -vf "drawtext=text='Stack Overflow':fontcolor=white:fontsize=24:box=1:boxcolor=black@0.5:boxborderw=5:x=(w-text_w)/2:y=(h-text_h)/2" outfile/sample-5s_1_with_text.mp4`
 ```
-
 </details>
 
 # Reviewing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,7 @@ In the bash shell, run the following commands
          but they are all there
    $ for i in ogg amr vorbis theora mp3lame opus vpx xvid fdk x264 x265;do echo $i; find /usr/local/ -name *$i*;done
    $ ffmpeg -buildconf
+   $ ffmpeg -filters 
 
 3: Convert an avi file to an mp4 file.
    `docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest -i drop_video_1.avi outfile/dv_converted.mp4`

--- a/docker-images/6.1/alpine320/Dockerfile
+++ b/docker-images/6.1/alpine320/Dockerfile
@@ -99,6 +99,7 @@ RUN         libDeps="libgomp \
                     fontconfig \
                     fontconfig-static \
                     fontconfig-dev \
+                    font-dejavu \
                     # https://github.com/libass/libass
                     libass \
                     libass-dev \
@@ -198,6 +199,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/docker-images/6.1/alpine320/build_source.sh
+++ b/docker-images/6.1/alpine320/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/6.1/ubuntu2404-edge/Dockerfile
+++ b/docker-images/6.1/ubuntu2404-edge/Dockerfile
@@ -198,6 +198,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
 
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/6.1/ubuntu2404-edge/build_source.sh
+++ b/docker-images/6.1/ubuntu2404-edge/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/6.1/ubuntu2404/Dockerfile
+++ b/docker-images/6.1/ubuntu2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -189,6 +189,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/6.1/ubuntu2404/build_source.sh
+++ b/docker-images/6.1/ubuntu2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/6.1/vaapi2404/Dockerfile
+++ b/docker-images/6.1/vaapi2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -193,7 +193,13 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 
 # Stage 2: Final Image ( shrink the size back down )
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/6.1/vaapi2404/build_source.sh
+++ b/docker-images/6.1/vaapi2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.0/alpine320/Dockerfile
+++ b/docker-images/7.0/alpine320/Dockerfile
@@ -99,6 +99,7 @@ RUN         libDeps="libgomp \
                     fontconfig \
                     fontconfig-static \
                     fontconfig-dev \
+                    font-dejavu \
                     # https://github.com/libass/libass
                     libass \
                     libass-dev \
@@ -198,6 +199,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/docker-images/7.0/alpine320/build_source.sh
+++ b/docker-images/7.0/alpine320/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.0/nvidia2404/Dockerfile
+++ b/docker-images/7.0/nvidia2404/Dockerfile
@@ -85,7 +85,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -212,6 +212,11 @@ COPY --from=builder /usr/local/bin /usr/local/bin/
 COPY --from=builder /usr/local/share /usr/local/share/
 COPY --from=builder /usr/local/lib /usr/local/lib/
 COPY --from=builder /usr/local/include /usr/local/include/
+
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 ENV	    DEBIAN_FRONTEND=nonintercative

--- a/docker-images/7.0/nvidia2404/build_source.sh
+++ b/docker-images/7.0/nvidia2404/build_source.sh
@@ -327,7 +327,9 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
         --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \

--- a/docker-images/7.0/scratch320/Dockerfile
+++ b/docker-images/7.0/scratch320/Dockerfile
@@ -201,7 +201,8 @@ FROM        alpine:3.20 AS release
 # Copy fonts and fontconfig from builder
 COPY        --from=builder /usr/share/fonts /usr/share/fonts
 COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
-COPY        --from=builder /usr/bin/fc-* /usr/bin/
+# Probably don't want the fc-* utilities in the scratch image
+# COPY        --from=builder /usr/bin/fc-* /usr/bin/
 
 # Copy rest of the content
 COPY        --from=builder /usr/local /usr/local

--- a/docker-images/7.0/scratch320/Dockerfile
+++ b/docker-images/7.0/scratch320/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    fribidi \
                    fribidi-static \
                    fribidi-dev\
+                   font-dejavu \
                    # https://github.com/libass/libass
                    libass \
                    libass-dev\
@@ -197,6 +198,12 @@ RUN /tmp/workdir/install_ffmpeg.sh --strip
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/docker-images/7.0/scratch320/build_source.sh
+++ b/docker-images/7.0/scratch320/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.0/ubuntu2404-edge/Dockerfile
+++ b/docker-images/7.0/ubuntu2404-edge/Dockerfile
@@ -198,6 +198,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
 
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.0/ubuntu2404-edge/build_source.sh
+++ b/docker-images/7.0/ubuntu2404-edge/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.0/ubuntu2404/Dockerfile
+++ b/docker-images/7.0/ubuntu2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -189,6 +189,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.0/ubuntu2404/build_source.sh
+++ b/docker-images/7.0/ubuntu2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.0/vaapi2404/Dockerfile
+++ b/docker-images/7.0/vaapi2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -193,7 +193,13 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 
 # Stage 2: Final Image ( shrink the size back down )
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.0/vaapi2404/build_source.sh
+++ b/docker-images/7.0/vaapi2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.1/alpine320/Dockerfile
+++ b/docker-images/7.1/alpine320/Dockerfile
@@ -99,6 +99,7 @@ RUN         libDeps="libgomp \
                     fontconfig \
                     fontconfig-static \
                     fontconfig-dev \
+                    font-dejavu \
                     # https://github.com/libass/libass
                     libass \
                     libass-dev \
@@ -198,6 +199,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/docker-images/7.1/alpine320/build_source.sh
+++ b/docker-images/7.1/alpine320/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.1/nvidia2404/Dockerfile
+++ b/docker-images/7.1/nvidia2404/Dockerfile
@@ -85,7 +85,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -212,6 +212,11 @@ COPY --from=builder /usr/local/bin /usr/local/bin/
 COPY --from=builder /usr/local/share /usr/local/share/
 COPY --from=builder /usr/local/lib /usr/local/lib/
 COPY --from=builder /usr/local/include /usr/local/include/
+
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
 
 ENV	    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 ENV	    DEBIAN_FRONTEND=nonintercative

--- a/docker-images/7.1/nvidia2404/build_source.sh
+++ b/docker-images/7.1/nvidia2404/build_source.sh
@@ -327,7 +327,9 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
         --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \

--- a/docker-images/7.1/scratch320/Dockerfile
+++ b/docker-images/7.1/scratch320/Dockerfile
@@ -201,7 +201,8 @@ FROM        alpine:3.20 AS release
 # Copy fonts and fontconfig from builder
 COPY        --from=builder /usr/share/fonts /usr/share/fonts
 COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
-COPY        --from=builder /usr/bin/fc-* /usr/bin/
+# Probably don't want the fc-* utilities in the scratch image
+# COPY        --from=builder /usr/bin/fc-* /usr/bin/
 
 # Copy rest of the content
 COPY        --from=builder /usr/local /usr/local

--- a/docker-images/7.1/scratch320/Dockerfile
+++ b/docker-images/7.1/scratch320/Dockerfile
@@ -65,6 +65,7 @@ RUN     buildDeps="autoconf \
                    fribidi \
                    fribidi-static \
                    fribidi-dev\
+                   font-dejavu \
                    # https://github.com/libass/libass
                    libass \
                    libass-dev\
@@ -197,6 +198,12 @@ RUN /tmp/workdir/install_ffmpeg.sh --strip
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/docker-images/7.1/scratch320/build_source.sh
+++ b/docker-images/7.1/scratch320/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.1/ubuntu2404-edge/Dockerfile
+++ b/docker-images/7.1/ubuntu2404-edge/Dockerfile
@@ -198,6 +198,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
 
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.1/ubuntu2404-edge/build_source.sh
+++ b/docker-images/7.1/ubuntu2404-edge/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.1/ubuntu2404/Dockerfile
+++ b/docker-images/7.1/ubuntu2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -189,6 +189,12 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.1/ubuntu2404/build_source.sh
+++ b/docker-images/7.1/ubuntu2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/docker-images/7.1/vaapi2404/Dockerfile
+++ b/docker-images/7.1/vaapi2404/Dockerfile
@@ -81,7 +81,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages
@@ -193,7 +193,13 @@ RUN /tmp/workdir/install_ffmpeg.sh
 
 
 # Stage 2: Final Image ( shrink the size back down )
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/docker-images/7.1/vaapi2404/build_source.sh
+++ b/docker-images/7.1/vaapi2404/build_source.sh
@@ -325,7 +325,10 @@ build_ffmpeg() {
         --enable-libbluray \
         --enable-libdav1d \
         --enable-libfdk-aac \
+        --enable-libfontconfig \
         --enable-libfreetype \
+        --enable-libfribidi \
+        --enable-libharfbuzz \
         --enable-libkvazaar \
         --enable-libmp3lame \
         --enable-libopencore-amrnb \

--- a/templates/Dockerfile-env-nvidia
+++ b/templates/Dockerfile-env-nvidia
@@ -65,7 +65,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages

--- a/templates/Dockerfile-env-ubuntu
+++ b/templates/Dockerfile-env-ubuntu
@@ -63,7 +63,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages

--- a/templates/Dockerfile-env-vaapi
+++ b/templates/Dockerfile-env-vaapi
@@ -63,7 +63,7 @@ ARG OPENJP_PKGS="libopenjp2-7 libopenjp2-7-dev"
 #  libwebp7 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxpm4 linux-libc-dev
 # manpages manpages-dev rpcsvc-proto zlib1g-dev
 ARG FREETYPE_PKGS="libfreetype6-dev"
-ARG FONTCONFIG_PKGS="libfontconfig-dev libfontconfig1 fontconfig-config fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
+ARG FONTCONFIG_PKGS="fontconfig libfontconfig-dev libfontconfig1 fontconfig-config fonts-dejavu-core fonts-dejavu-mono"
 ARG VIDSTAB_PKGS="libvidstab-dev libvidstab1.1"
 ARG FRIBIDI_PKGS="libfribidi-dev libfribidi0"
 # libass-dev wanted to install a boat-load of packages

--- a/templates/Dockerfile-template.alpine320
+++ b/templates/Dockerfile-template.alpine320
@@ -92,6 +92,7 @@ RUN         libDeps="libgomp \
                     fontconfig \
                     fontconfig-static \
                     fontconfig-dev \
+                    font-dejavu \
                     # https://github.com/libass/libass
                     libass \
                     libass-dev \
@@ -171,6 +172,12 @@ RUN     buildDeps="autoconf \
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/templates/Dockerfile-template.nvidia2404
+++ b/templates/Dockerfile-template.nvidia2404
@@ -88,6 +88,11 @@ COPY --from=builder /usr/local/share /usr/local/share/
 COPY --from=builder /usr/local/lib /usr/local/lib/
 COPY --from=builder /usr/local/include /usr/local/include/
 
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
 ENV	    NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 ENV	    DEBIAN_FRONTEND=nonintercative
 WORKDIR     /tmp/workdir

--- a/templates/Dockerfile-template.scratch320
+++ b/templates/Dockerfile-template.scratch320
@@ -82,7 +82,8 @@ FROM        alpine:3.20 AS release
 # Copy fonts and fontconfig from builder
 COPY        --from=builder /usr/share/fonts /usr/share/fonts
 COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
-COPY        --from=builder /usr/bin/fc-* /usr/bin/
+# Probably don't want the fc-* utilities in the scratch image
+# COPY        --from=builder /usr/bin/fc-* /usr/bin/
 
 # Copy rest of the content
 COPY        --from=builder /usr/local /usr/local

--- a/templates/Dockerfile-template.scratch320
+++ b/templates/Dockerfile-template.scratch320
@@ -58,6 +58,7 @@ RUN     buildDeps="autoconf \
                    fribidi \
                    fribidi-static \
                    fribidi-dev\
+                   font-dejavu \
                    # https://github.com/libass/libass
                    libass \
                    libass-dev\
@@ -78,6 +79,12 @@ RUN     buildDeps="autoconf \
 ### Release Stage
 FROM        alpine:3.20 AS release
 # RUN         apk add --no-cache --update bash less tree file vim
+# Copy fonts and fontconfig from builder
+COPY        --from=builder /usr/share/fonts /usr/share/fonts
+COPY        --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY        --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY        --from=builder /usr/local /usr/local
 COPY        --from=builder /tmp/fakeroot/ /
 

--- a/templates/Dockerfile-template.ubuntu2404
+++ b/templates/Dockerfile-template.ubuntu2404
@@ -70,6 +70,12 @@ RUN      buildDeps="autoconf \
 
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/templates/Dockerfile-template.ubuntu2404-edge
+++ b/templates/Dockerfile-template.ubuntu2404-edge
@@ -72,6 +72,12 @@ RUN      buildDeps="autoconf \
 # Stage 2: Final Image ( shrink the size back down )
 FROM ubuntu:24.04 AS runtime
 
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/templates/Dockerfile-template.vaapi2404
+++ b/templates/Dockerfile-template.vaapi2404
@@ -70,7 +70,13 @@ RUN      buildDeps="autoconf \
 
 
 # Stage 2: Final Image ( shrink the size back down )
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS runtime
+# Copy fonts and fontconfig from builder
+COPY --from=builder /usr/share/fonts /usr/share/fonts
+COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
+COPY --from=builder /usr/bin/fc-* /usr/bin/
+
+# Copy rest of the content
 COPY --from=builder /usr/local /usr/local/
 
 LABEL       org.opencontainers.image.authors="julien@rottenberg.info" \

--- a/update.py
+++ b/update.py
@@ -201,7 +201,11 @@ for version in keep_version:
             "--enable-fontconfig",
             "--enable-libass",
             "--enable-libbluray",
+            # https://ffmpeg.org/ffmpeg-filters.html#drawtext-1
             "--enable-libfreetype",
+            "--enable-libharfbuzz",
+            "--enable-libfontconfig",
+            "--enable-libfribidi",
             "--enable-libmp3lame",
             "--enable-libopencore-amrnb",
             "--enable-libopencore-amrwb",
@@ -271,7 +275,6 @@ for version in keep_version:
                 FFMPEG_CONFIG_FLAGS.append("--enable-cuda")
                 FFMPEG_CONFIG_FLAGS.append("--enable-cuvid")
                 FFMPEG_CONFIG_FLAGS.append("--enable-libnpp")
-                FFMPEG_CONFIG_FLAGS.append("--enable-libharfbuzz")
 
         if float(version[0:3]) >= 5.1:
             # from https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu#FFmpeg


### PR DESCRIPTION
## Fix summary 

resolves: #412 

<details><summary>Problems Before Change</summary>
### Summary of current problems

| Image | Current state |
| --- | --- |
| jrottenberg/ffmpeg:7.1-ubuntu2404 | `Filter not found` |
| jrottenberg/ffmpeg:7.1-ubuntu2404-edge | `Filter not found` |
| jrottenberg/ffmpeg:6.1.2-ubuntu2404 | `Filter not found` |
| jrottenberg/ffmpeg:6.1.2-ubuntu2404-edge | `Filter not found` |
| jrottenberg/ffmpeg-7.1-nvidi2404 | `Cannot find a valid font for the family Sans` |
| jrottenberg/ffmpeg:7.1-alpine320 | `Filter not found` |
| jrottenberg/ffmpeg:7.1-scratch320 | `Filter not found` |
| jrottenberg/ffmpeg:7.1-vaapi2404 | `Filter not found` |
</details>

- added `enable-libharfbuzz`, `enable-libfontconfig`, `enable-libfribidi` to ffmpeg build conf.
- added `COPY` `/usr/share/fonts`,  `/usr/share/fontconfig`, `/usr/bin/fc-*` the final docker stage for fontconfig support.
- added `fontconfig` to the packages. ( for completeness ) 

- Os flavors: 
    - [x]  `<ffmpeg-ver>-ubuntu2404`
    - [x] `<ffmpeg-ver>-ubuntu2404-edge`
    - `<ffmpeg-ver>-vaapi2404`  ( does not work here 🤷‍♂️ , may need to be a separate PR )
    - [x] `<ffmpeg-ver>-nvidia2404`
    - [x] `<ffmpeg-ver>-alpine320`
    - [x] `<ffmpeg-ver>-scratch320`

Here is an example video with the drawtext used, to draw the word `Fire !`

https://github.com/user-attachments/assets/7f66444a-c9bc-4909-8c51-0fe2ab28a0ab



Convert video to smaller video
```
docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest -i IMG_5428.MOV -ss 00:00:02 -t 00:00:01.5 -vf scale=iw/2:-2 -c:v libx264 -c:a copy outfile/solo_stove_slow_mo.mp4
```
Now add some text using ffmpeg `-vf "drawtext=text='Fire !'`
```
docker run --rm -v $(pwd):$(pwd) -w $(pwd) --platform="linux/amd64" ffmpeg-7.1-ubuntu2404-desktop-build:latest -i outfile/solo_stove_slow_mo.mp4 -vf "drawtext=text='Fire !':fontcolor=orange:fontsize=48:x=(w-text_w)/2:y=(h-text_h)/4" outfile/solo_stove_slow_mo_w_text.mp4
```


additional details are here: https://github.com/jrottenberg/ffmpeg/issues/412#issuecomment-2466497544